### PR TITLE
refactor: harden linter config and fix lint findings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,7 +38,6 @@ Flat verbs for authoring, `hub` subcommand for catalog operations.
 - `hub_publish.go` — Publish a listing to the hub
 - `hub_deprecate.go` — Deprecate a hub bundle
 - `hub_undeprecate.go` — Remove deprecation from a hub bundle
-- `hub_star.go` — Star/unstar hub bundles
 - `doctor.go` — Diagnostic checks
 - `update.go` — Self-update
 - `version.go` — Version display
@@ -77,7 +76,7 @@ Flat verbs for authoring, `hub` subcommand for catalog operations.
 
 **No TUI** — Publishing is batch-oriented. No bubbletea, no tcell, no PTY.
 
-**Shared namespace** — Both Musher and Mush share `~/.config/musher/`, keyring `dev.musher.musher`, env var `MUSHER_API_KEY`.
+**Shared namespace** — Both Musher and Mush share `~/.config/musher/`, keyring `musher/{hostname}`, env var `MUSHER_API_KEY`.
 
 ## Development
 
@@ -93,7 +92,8 @@ task fmt          # Format code
 - **Binary**: `musher`
 - **Config dir**: `~/.config/musher/` (XDG)
 - **State dir**: `~/.local/state/musher/` (XDG)
-- **Credentials**: OS Keyring (`dev.musher.musher`), falls back to `~/.config/musher/api-key`
+- **Data dir**: `~/.local/share/musher/` (XDG)
+- **Credentials**: OS Keyring (`musher/{hostname}`), falls back to `~/.local/share/musher/credentials/{hostID}/api-key`
 - **Logs**: `~/.local/state/musher/logs/musher.log` (default sink)
 - **API endpoint**: `api.url` config key or `MUSHER_API_URL` env var
 - **Auth**: `MUSHER_API_KEY` env var or `musher login`

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
+
+[*.go]
+indent_style = tab
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,13 +45,23 @@ linters:
     - wastedassign    # Detect wasted assignments
     - godot           # Require period at end of comments
     - whitespace      # Remove unnecessary blank lines
+    - intrange        # Go 1.22+ integer range suggestions
+    - reassign        # Package-level variable reassignment detection
+    - containedctx    # context.Context in structs
+    - makezero        # Slice initialization correctness
+    - mirror          # Prefer mirror stdlib functions
+    - perfsprint      # Faster string formatting alternatives
+    - sloglint        # Consistent slog usage
+    - exhaustive      # Exhaustive switch/map on enums
+    - goconst         # Repeated literals that should be constants
+    - nakedret        # Naked returns in long functions
   settings:
     govet:
       enable:
         - shadow        # Variable shadowing detection
     errcheck:
       check-type-assertions: true
-      check-blank: false
+      check-blank: true
       exclude-functions:
         - fmt.Fprint
         - fmt.Fprintf
@@ -65,12 +75,28 @@ linters:
       severity: error
       rules:
         - name: exported
-          disabled: false
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: if-return
+        - name: increment-decrement
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
     gocritic:
       enabled-tags:
         - diagnostic
         - style
         - performance
+        - opinionated
     depguard:
       rules:
         internal_no_cmd_import:
@@ -114,7 +140,6 @@ linters:
       excludes:
         - G104
         - G115
-        - G304
         - G703
         - G704
       config:
@@ -153,22 +178,26 @@ linters:
         - c
         - p
         - r
-        - h
-        - s
-        - b
-        - n
-        - f
       ignore-decls:
         - c *cobra.Command
         - c *client.Client
         - p *prompt.Prompter
         - w http.ResponseWriter
         - r *http.Request
+        - f *os.File
+        - h slog.Handler
     nolintlint:
       require-explanation: true
       require-specific: true
     godot:
       scope: declarations
+    exhaustive:
+      default-signifies-exhaustive: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    nakedret:
+      max-func-lines: 15
   exclusions:
     rules:
       - path: _test\.go
@@ -180,9 +209,9 @@ linters:
       - path: _test\.go
         linters:
           - varnamelen
-      - path: internal/.*
+      - path: _test\.go
         linters:
-          - gocognit
+          - goconst
 
 formatters:
   enable:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Publish agent bundles to the [Musher](https://musher.dev) registry.
 
+[Docs](https://docs.musher.dev) | [Hub](https://hub.musher.dev) | [Releases](https://github.com/musher-dev/musher-cli/releases)
+
 Musher is the publishing companion to [Mush](https://github.com/musher-dev/mush) — while Mush loads and runs bundles locally, Musher handles creating, validating, and publishing them. Think `docker push` vs `docker run`.
 
 ## Install
@@ -10,34 +12,45 @@ Musher is the publishing companion to [Mush](https://github.com/musher-dev/mush)
 # From GitHub Releases
 curl -fsSL https://get.musher.dev | sh
 
-# Or with Go
+# From source (requires Go 1.26.1+)
 go install github.com/musher-dev/musher-cli/cmd/musher@latest
 ```
 
 ## Quick Start
 
 ```bash
-# Authenticate
 musher login
 
-# Initialize a bundle definition file
 musher init
+# Creates: musher.yaml, skills/<slug>/SKILL.md, README.md
+# Use --empty to create musher.yaml only
 
-# Validate your bundle
 musher validate
-
-# Push to the registry
 musher push
+
+# Optional: list on the public Hub catalog
+musher hub publish <namespace/slug>
 ```
+
+## Registry vs Hub
+
+Musher has a two-step publishing model:
+
+1. **`musher push`** uploads your bundle to the **registry** (private by default).
+2. **`musher hub publish`** creates or updates a public **Hub catalog listing** for a pushed bundle.
+
+You can push bundles without listing them on the Hub. Hub publishing requires additional metadata: `description`, `readme`, and `license` or `licenseFile`.
 
 ## Core Concepts
 
-- **Bundle** — A versioned package of assets (skills, prompts, configs) published to the Musher Hub.
-- **Asset** — A single file within a bundle (e.g. a skill markdown file, a prompt template).
-- **Bundle definition file** — The `musher.yaml` file that describes your bundle's metadata and assets.
-- **Namespace** — The publishing identity under which bundles are published (e.g. `acme/my-bundle`).
+- **Bundle** — A versioned package of assets (skills, agents, prompts, tools, configs) pushed to the Musher registry.
+- **Asset** — A single file within a bundle (e.g., a skill markdown file, a prompt template, an agent spec).
+- **Bundle definition** — The `musher.yaml` file that describes your bundle's metadata and assets.
+- **Namespace** — The publishing identity under which bundles are published (e.g., `acme/my-bundle`).
 
 ## `musher.yaml` Bundle Definition
+
+**Minimal (private) bundle:**
 
 ```yaml
 namespace: acme
@@ -45,30 +58,38 @@ slug: my-skill
 version: 1.0.0
 name: My Skill Bundle
 description: A helpful coding skill
-keywords:
-  - productivity
-  - coding
 assets:
   - id: my-skill
     src: skills/my-skill/SKILL.md
 ```
 
-Example skill file:
+**Hub-ready (public) bundle:**
 
-```md
----
-name: my-skill
-description: A helpful coding skill. Use when the task matches this bundle's specialization.
----
-
-# My Skill
-
-Add the instructions the agent should follow here.
+```yaml
+namespace: acme
+slug: code-review
+version: 0.1.0
+name: Team Code Review
+description: Consistent code review guidance for engineering teams
+visibility: public
+readme: README.md
+licenseFile: LICENSE
+repository: https://github.com/acme/code-review-bundle
+keywords:
+  - code-review
+  - engineering
+assets:
+  - id: code-review
+    src: skills/code-review/SKILL.md
+  - id: review-agent
+    src: agents/review-agent/AGENT.yaml
+    kind: agent
 ```
 
 ## Commands
 
 ### Authentication
+
 | Command | Description |
 |---------|-------------|
 | `musher login` | Authenticate with API key |
@@ -76,28 +97,29 @@ Add the instructions the agent should follow here.
 | `musher whoami` | Show current identity and writable namespaces |
 
 ### Publishing
+
 | Command | Description |
 |---------|-------------|
-| `musher init` | Create a `musher.yaml` bundle definition file |
-| `musher validate` | Validate bundle definition file and assets |
-| `musher push` | Validate and push the bundle to the registry |
-| `musher yank <ns/slug:version>` | Yank a published version (hidden from search, fetchable by digest) |
+| `musher init` | Scaffold a bundle project (`musher.yaml`, skill template, `README.md`). Use `--empty` for definition only |
+| `musher validate` | Validate bundle definition and assets |
+| `musher push` | Push the bundle to the registry |
+| `musher yank <ns/slug:version>` | Yank a published version |
 | `musher unyank <ns/slug:version>` | Restore a yanked version |
 
 ### Hub
+
 | Command | Description |
 |---------|-------------|
-| `musher hub search <query>` | Search for bundles on the Hub |
-| `musher hub info <namespace/slug>` | Show details for a Hub bundle |
+| `musher hub search [query]` | Search bundles (omit query for recently updated bundles) |
+| `musher hub info <namespace/slug>` | Show bundle details |
 | `musher hub list <namespace>` | List bundles for a namespace |
 | `musher hub categories` | List Hub categories |
 | `musher hub publish <namespace/slug>` | Create or update a Hub listing |
-| `musher hub deprecate <namespace/slug>` | Deprecate a Hub bundle |
-| `musher hub undeprecate <namespace/slug>` | Remove deprecation from a Hub bundle |
-
-> **Two-step flow:** `musher push` uploads your bundle to the registry. `musher hub publish` creates or updates the public catalog listing.
+| `musher hub deprecate <namespace/slug>` | Deprecate a bundle |
+| `musher hub undeprecate <namespace/slug>` | Remove deprecation |
 
 ### Maintenance
+
 | Command | Description |
 |---------|-------------|
 | `musher doctor` | Diagnostic checks |
@@ -107,26 +129,40 @@ Add the instructions the agent should follow here.
 
 ## Configuration
 
-- **Config dir**: `~/.config/musher/`
-- **Credentials**: OS Keyring (`dev.musher.musher`) or `~/.config/musher/api-key`
-- **Logs**: `~/.local/state/musher/logs/musher.log`
-- **API endpoint**: `MUSHER_API_URL` or `api.url` config key (default: `https://api.musher.dev`)
-- **Auth**: `MUSHER_API_KEY` env var or `musher login`
+| Item | Location |
+|------|----------|
+| Config file | `~/.config/musher/config.yaml` |
+| Credentials (keyring) | OS keyring, service `musher/<api-host>` |
+| Credentials (fallback) | `~/.local/share/musher/credentials/<hostID>/api-key` |
+| Logs | `~/.local/state/musher/logs/musher.log` |
+
+**Auth precedence:** `MUSHER_API_KEY` env var / `--api-key` flag > OS keyring > credentials file.
+
+**API endpoint:** `--api-url` flag > `MUSHER_API_URL` env var > `api.url` config key (default: `https://api.musher.dev`).
+
+All paths follow XDG conventions. Override with `MUSHER_CONFIG_HOME`, `MUSHER_DATA_HOME`, `MUSHER_STATE_HOME`, or `MUSHER_HOME`.
 
 ## Development
 
+Requires [Go 1.26.1+](https://go.dev/dl/) and [Task](https://taskfile.dev/).
+
 ```bash
-task setup         # Download deps, install pinned tools, install hooks
-task build         # Build binary
-task check:ci      # Run the canonical quality gate
-task check:test    # Run tests only
-task check:shell   # Lint shell scripts
+task setup          # Download deps, install pinned tools, install hooks
+task build          # Build binary
+task check          # Full quality suite (fmt + lint + vuln + test)
+task check:ci       # Canonical CI quality gate
+task check:test     # Run tests only
+task check:shell    # Lint shell scripts (requires shellcheck on PATH)
 task check:workflow # Lint GitHub Actions workflows
-task fmt           # Format Go and shell code, then tidy modules
+task fmt            # Format Go and shell code, tidy modules
 ```
 
-Local hooks are managed by `lefthook` and are installed automatically by `task setup`.
+Local hooks are managed by [Lefthook](https://github.com/evilmartians/lefthook) and installed automatically by `task setup`.
+
+## Contributing
+
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/cmd/musher/bootstrap.go
+++ b/cmd/musher/bootstrap.go
@@ -73,7 +73,7 @@ func wrapPostRunCleanup(postRun func(*cobra.Command, []string) error, cleanup fu
 	return func(cmd *cobra.Command, args []string) error {
 		if postRun != nil {
 			if err := postRun(cmd, args); err != nil {
-				_ = cleanup()
+				_ = cleanup() //nolint:errcheck // best-effort cleanup
 				return err
 			}
 		}

--- a/cmd/musher/hub_list.go
+++ b/cmd/musher/hub_list.go
@@ -37,13 +37,13 @@ func runHubList(cmd *cobra.Command, out *output.Writer, namespace string, limit 
 		c = newPublicAPIClient(cfg)
 	}
 
-	spin := out.Spinner(fmt.Sprintf("Listing bundles for %s", namespace))
+	spin := out.Spinner("Listing bundles for " + namespace)
 	spin.Start()
 
 	result, err := c.ListPublisherBundles(cmd.Context(), namespace, limit, "")
 	if err != nil {
 		spin.StopWithFailure("Failed to list bundles")
-		return clierrors.Wrap(clierrors.ExitGeneral, fmt.Sprintf("Failed to list bundles for %s", namespace), err)
+		return clierrors.Wrap(clierrors.ExitGeneral, "Failed to list bundles for "+namespace, err)
 	}
 
 	spin.Stop()
@@ -62,15 +62,15 @@ func runHubList(cmd *cobra.Command, out *output.Writer, namespace string, limit 
 	}
 
 	for i := range result.Data {
-		b := &result.Data[i]
-		out.Print("%s/%s", b.Publisher.Handle, b.Slug)
-		if b.LatestVersion != "" {
-			out.Print(":%s", b.LatestVersion)
+		bundle := &result.Data[i]
+		out.Print("%s/%s", bundle.Publisher.Handle, bundle.Slug)
+		if bundle.LatestVersion != "" {
+			out.Print(":%s", bundle.LatestVersion)
 		}
 		out.Print("\n")
 
-		if b.Summary != "" {
-			out.Muted("  %s", b.Summary)
+		if bundle.Summary != "" {
+			out.Muted("  %s", bundle.Summary)
 		}
 	}
 

--- a/cmd/musher/hub_publish.go
+++ b/cmd/musher/hub_publish.go
@@ -36,7 +36,7 @@ func runHubPublish(cmd *cobra.Command, out *output.Writer, ref string) error {
 	}
 
 	// If a local musher.yaml exists, validate hub-readiness before proceeding.
-	workDir, _ := os.Getwd()
+	workDir, _ := os.Getwd() //nolint:errcheck // non-critical working directory lookup
 	if def, loadErr := bundledef.Load(workDir); loadErr == nil {
 		if hubErr := def.ValidateHubReadiness(); hubErr != nil {
 			return clierrors.Wrap(clierrors.ExitGeneral, "Bundle not ready for Hub publishing", hubErr)

--- a/cmd/musher/hub_search.go
+++ b/cmd/musher/hub_search.go
@@ -94,19 +94,19 @@ func runHubSearch(cmd *cobra.Command, out *output.Writer, query, bundleType, sor
 	}
 
 	for i := range result.Data {
-		b := &result.Data[i]
-		out.Print("%s/%s", b.Publisher.Handle, b.Slug)
-		if b.LatestVersion != "" {
-			out.Print(":%s", b.LatestVersion)
+		bundle := &result.Data[i]
+		out.Print("%s/%s", bundle.Publisher.Handle, bundle.Slug)
+		if bundle.LatestVersion != "" {
+			out.Print(":%s", bundle.LatestVersion)
 		}
 		out.Print("\n")
 
-		if b.Summary != "" {
-			out.Muted("  %s", b.Summary)
+		if bundle.Summary != "" {
+			out.Muted("  %s", bundle.Summary)
 		}
 
 		out.Muted("  %s | %d stars | %d downloads",
-			fmt.Sprintf("%v", b.AssetTypes), b.StarsCount, b.DownloadsTotal)
+			fmt.Sprintf("%v", bundle.AssetTypes), bundle.StarsCount, bundle.DownloadsTotal)
 	}
 
 	if result.Meta.HasMore {

--- a/cmd/musher/init.go
+++ b/cmd/musher/init.go
@@ -16,6 +16,8 @@ import (
 	"github.com/musher-dev/musher-cli/internal/output"
 )
 
+const placeholderNamespace = "your-namespace"
+
 func newInitCmd() *cobra.Command {
 	var (
 		force bool
@@ -48,21 +50,21 @@ Edit it to configure your bundle before publishing.`,
 
 // sanitizeSlug turns a directory name into a valid bundle slug.
 func sanitizeSlug(name string) string {
-	s := strings.ToLower(name)
-	s = regexp.MustCompile(`[^a-z0-9-]`).ReplaceAllString(s, "-")
-	s = regexp.MustCompile(`-{2,}`).ReplaceAllString(s, "-")
-	s = strings.Trim(s, "-")
+	slug := strings.ToLower(name)
+	slug = regexp.MustCompile(`[^a-z0-9-]`).ReplaceAllString(slug, "-")
+	slug = regexp.MustCompile(`-{2,}`).ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
 
-	if len(s) > 100 {
-		s = s[:100]
-		s = strings.TrimRight(s, "-")
+	if len(slug) > 100 {
+		slug = slug[:100]
+		slug = strings.TrimRight(slug, "-")
 	}
 
-	if s == "" {
+	if slug == "" {
 		return "my-bundle"
 	}
 
-	return s
+	return slug
 }
 
 // slugToName converts a slug like "my-cool-bundle" to "My Cool Bundle".
@@ -122,17 +124,17 @@ type initData struct {
 func resolveNamespace(out *output.Writer) string {
 	_, c, err := newAPIClient()
 	if err != nil {
-		return "your-namespace"
+		return placeholderNamespace
 	}
 
 	identity, err := c.GetPublisherIdentity(context.Background())
 	if err != nil {
-		return "your-namespace"
+		return placeholderNamespace
 	}
 
 	switch len(identity.Namespaces) {
 	case 0:
-		return "your-namespace"
+		return placeholderNamespace
 	case 1:
 		return identity.Namespaces[0].Handle
 	default:
@@ -143,7 +145,7 @@ func resolveNamespace(out *output.Writer) string {
 
 		out.Info("Multiple namespaces available: %s", strings.Join(handles, ", "))
 
-		return "your-namespace"
+		return placeholderNamespace
 	}
 }
 
@@ -243,7 +245,7 @@ Follow these steps:
 	out.Println()
 	out.Info("Next steps:")
 
-	if namespace == "your-namespace" {
+	if namespace == placeholderNamespace {
 		out.Info("  1. Set 'namespace' in musher.yaml (run 'musher whoami' to see your namespaces)")
 	} else {
 		out.Info("  1. Namespace set to '%s' — change if needed", namespace)
@@ -262,7 +264,7 @@ func writeTemplate(path string, tmpl *template.Template, data initData) error {
 		return fmt.Errorf("create %s: %w", filepath.Base(path), err)
 	}
 
-	defer func() { _ = f.Close() }()
+	defer func() { _ = f.Close() }() //nolint:errcheck // best-effort cleanup
 
 	if err := tmpl.Execute(f, data); err != nil {
 		return fmt.Errorf("write template to %s: %w", filepath.Base(path), err)

--- a/cmd/musher/push.go
+++ b/cmd/musher/push.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -77,7 +76,7 @@ func runPush(cmd *cobra.Command, out *output.Writer) error {
 
 		data, readErr := safeio.ReadFile(assetPath)
 		if readErr != nil {
-			return clierrors.Wrap(clierrors.ExitGeneral, fmt.Sprintf("Failed to read asset: %s", asset.Src), readErr)
+			return clierrors.Wrap(clierrors.ExitGeneral, "Failed to read asset: "+asset.Src, readErr)
 		}
 
 		assets = append(assets, client.PushBundleAsset{
@@ -103,7 +102,7 @@ func runPush(cmd *cobra.Command, out *output.Writer) error {
 	}
 
 	// Push bundle in a single request
-	spin := out.Spinner(fmt.Sprintf("Pushing %s", bundle.VersionRef()))
+	spin := out.Spinner("Pushing " + bundle.VersionRef())
 	spin.Start()
 
 	if pushErr := c.PushBundle(ctx, bundle.Namespace, bundle.Slug, req); pushErr != nil {
@@ -122,7 +121,7 @@ func runPush(cmd *cobra.Command, out *output.Writer) error {
 		return clierrors.PublishFailed(pushErr)
 	}
 
-	spin.StopWithSuccess(fmt.Sprintf("Pushed %s", bundle.VersionRef()))
+	spin.StopWithSuccess("Pushed " + bundle.VersionRef())
 
 	return nil
 }
@@ -183,7 +182,7 @@ func handleVisibilityRecovery(
 	// Update in-memory request and retry.
 	req.Visibility = "public"
 
-	spin := out.Spinner(fmt.Sprintf("Retrying push %s", bundle.VersionRef()))
+	spin := out.Spinner("Retrying push " + bundle.VersionRef())
 	spin.Start()
 
 	if retryErr := c.PushBundle(cmd.Context(), bundle.Namespace, bundle.Slug, req); retryErr != nil {
@@ -191,7 +190,7 @@ func handleVisibilityRecovery(
 		return clierrors.PublishFailed(retryErr)
 	}
 
-	spin.StopWithSuccess(fmt.Sprintf("Pushed %s (public)", bundle.VersionRef()))
+	spin.StopWithSuccess("Pushed " + bundle.VersionRef() + " (public)")
 
 	return nil
 }

--- a/cmd/musher/root.go
+++ b/cmd/musher/root.go
@@ -12,6 +12,14 @@ import (
 	"github.com/musher-dev/musher-cli/internal/validate"
 )
 
+// Command group IDs.
+const (
+	groupAuth        = "auth"
+	groupPublish     = "publish"
+	groupHub         = "hub"
+	groupMaintenance = "maintenance"
+)
+
 func newRootCmd() *cobra.Command {
 	var (
 		jsonOutput bool
@@ -101,10 +109,10 @@ listings.`,
 	rootCmd.PersistentFlags().StringVar(&apiURL, "api-url", "", "Override Musher API URL for this command")
 	rootCmd.PersistentFlags().StringVar(&apiKey, "api-key", "", "API key override (prefer MUSHER_API_KEY env var)")
 
-	_ = rootCmd.PersistentFlags().MarkHidden("log-level")
-	_ = rootCmd.PersistentFlags().MarkHidden("log-format")
-	_ = rootCmd.PersistentFlags().MarkHidden("log-file")
-	_ = rootCmd.PersistentFlags().MarkHidden("log-stderr")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-level")  //nolint:errcheck // MarkHidden cannot fail for registered flags
+	_ = rootCmd.PersistentFlags().MarkHidden("log-format") //nolint:errcheck // MarkHidden cannot fail for registered flags
+	_ = rootCmd.PersistentFlags().MarkHidden("log-file")   //nolint:errcheck // MarkHidden cannot fail for registered flags
+	_ = rootCmd.PersistentFlags().MarkHidden("log-stderr") //nolint:errcheck // MarkHidden cannot fail for registered flags
 
 	rootCmd.SuggestionsMinimumDistance = 2
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
@@ -122,66 +130,66 @@ listings.`,
 
 func registerRootCommands(rootCmd *cobra.Command) {
 	rootCmd.AddGroup(
-		&cobra.Group{ID: "auth", Title: "Authentication:"},
-		&cobra.Group{ID: "publish", Title: "Publishing:"},
-		&cobra.Group{ID: "hub", Title: "Hub:"},
-		&cobra.Group{ID: "maintenance", Title: "Maintenance:"},
+		&cobra.Group{ID: groupAuth, Title: "Authentication:"},
+		&cobra.Group{ID: groupPublish, Title: "Publishing:"},
+		&cobra.Group{ID: groupHub, Title: "Hub:"},
+		&cobra.Group{ID: groupMaintenance, Title: "Maintenance:"},
 	)
 
 	// Auth group
 	loginCmd := newLoginCmd()
-	loginCmd.GroupID = "auth"
+	loginCmd.GroupID = groupAuth
 	rootCmd.AddCommand(loginCmd)
 
 	logoutCmd := newLogoutCmd()
-	logoutCmd.GroupID = "auth"
+	logoutCmd.GroupID = groupAuth
 	rootCmd.AddCommand(logoutCmd)
 
 	whoamiCmd := newWhoamiCmd()
-	whoamiCmd.GroupID = "auth"
+	whoamiCmd.GroupID = groupAuth
 	rootCmd.AddCommand(whoamiCmd)
 
 	// Publish group
 	initCmd := newInitCmd()
-	initCmd.GroupID = "publish"
+	initCmd.GroupID = groupPublish
 	rootCmd.AddCommand(initCmd)
 
 	validateCmd := newValidateCmd()
-	validateCmd.GroupID = "publish"
+	validateCmd.GroupID = groupPublish
 	rootCmd.AddCommand(validateCmd)
 
 	pushCmd := newPushCmd()
-	pushCmd.GroupID = "publish"
+	pushCmd.GroupID = groupPublish
 	rootCmd.AddCommand(pushCmd)
 
 	yankCmd := newYankCmd()
-	yankCmd.GroupID = "publish"
+	yankCmd.GroupID = groupPublish
 	rootCmd.AddCommand(yankCmd)
 
 	unyankCmd := newUnyankCmd()
-	unyankCmd.GroupID = "publish"
+	unyankCmd.GroupID = groupPublish
 	rootCmd.AddCommand(unyankCmd)
 
 	// Hub group
 	hubCmd := newHubCmd()
-	hubCmd.GroupID = "hub"
+	hubCmd.GroupID = groupHub
 	rootCmd.AddCommand(hubCmd)
 
 	// Maintenance group
 	doctorCmd := newDoctorCmd()
-	doctorCmd.GroupID = "maintenance"
+	doctorCmd.GroupID = groupMaintenance
 	rootCmd.AddCommand(doctorCmd)
 
 	updateCmd := newUpdateCmd()
-	updateCmd.GroupID = "maintenance"
+	updateCmd.GroupID = groupMaintenance
 	rootCmd.AddCommand(updateCmd)
 
 	versionCmd := newVersionCmd()
-	versionCmd.GroupID = "maintenance"
+	versionCmd.GroupID = groupMaintenance
 	rootCmd.AddCommand(versionCmd)
 
 	completionCmd := newCompletionCmd()
-	completionCmd.GroupID = "maintenance"
+	completionCmd.GroupID = groupMaintenance
 	rootCmd.AddCommand(completionCmd)
 }
 

--- a/cmd/musher/update.go
+++ b/cmd/musher/update.go
@@ -124,7 +124,7 @@ func runUpdate(cmd *cobra.Command, out *output.Writer, targetVersion string, for
 	if info.UpdateAvailable {
 		spin.StopWithSuccess(fmt.Sprintf("Update available: v%s -> v%s", currentVersion, info.LatestVersion))
 	} else {
-		spin.StopWithSuccess(fmt.Sprintf("Reinstalling v%s", info.LatestVersion))
+		spin.StopWithSuccess("Reinstalling v" + info.LatestVersion)
 	}
 
 	reexeced, err := ensureUpdateWritable(install)
@@ -136,7 +136,7 @@ func runUpdate(cmd *cobra.Command, out *output.Writer, targetVersion string, for
 		return nil
 	}
 
-	spin = out.Spinner(fmt.Sprintf("Downloading v%s", info.LatestVersion))
+	spin = out.Spinner("Downloading v" + info.LatestVersion)
 	spin.Start()
 
 	if err := updater.Apply(ctx, info.Release); err != nil {
@@ -146,7 +146,7 @@ func runUpdate(cmd *cobra.Command, out *output.Writer, targetVersion string, for
 			WithHint("Try again or download manually from GitHub Releases")
 	}
 
-	spin.StopWithSuccess(fmt.Sprintf("Updated to v%s", info.LatestVersion))
+	spin.StopWithSuccess("Updated to v" + info.LatestVersion)
 
 	if info.ReleaseURL != "" {
 		out.Muted("Release notes: %s", info.ReleaseURL)
@@ -169,7 +169,7 @@ func updateToVersion(ctx context.Context, out *output.Writer, updater *update.Up
 
 	var spin *output.Spinner
 	if !out.JSON {
-		spin = out.Spinner(fmt.Sprintf("Installing v%s", version))
+		spin = out.Spinner("Installing v" + version)
 		spin.Start()
 	}
 
@@ -179,7 +179,7 @@ func updateToVersion(ctx context.Context, out *output.Writer, updater *update.Up
 			spin.Stop()
 		}
 
-		cliErr := clierrors.Wrap(clierrors.ExitGeneral, fmt.Sprintf("Failed to install v%s", version), err)
+		cliErr := clierrors.Wrap(clierrors.ExitGeneral, "Failed to install v"+version, err)
 		if strings.Contains(err.Error(), "not found") {
 			cliErr = cliErr.WithHint("Check available versions at https://github.com/musher-dev/musher-cli/releases")
 		}
@@ -188,14 +188,14 @@ func updateToVersion(ctx context.Context, out *output.Writer, updater *update.Up
 	}
 
 	if spin != nil {
-		spin.StopWithSuccess(fmt.Sprintf("Installed v%s", release.Version()))
+		spin.StopWithSuccess("Installed v" + release.Version())
 	}
 
 	return nil
 }
 
 func saveCheckState(current, latest, releaseURL string) {
-	_ = update.SaveCheckResult(current, latest, releaseURL)
+	_ = update.SaveCheckResult(current, latest, releaseURL) //nolint:errcheck // best-effort state persistence
 }
 
 func ensureUpdateWritable(install update.InstallContext) (bool, error) {

--- a/cmd/musher/validate.go
+++ b/cmd/musher/validate.go
@@ -37,7 +37,7 @@ func runValidate(out *output.Writer) error {
 	// Run schema validation first.
 	yamlPath := filepath.Join(workDir, bundledef.FileName)
 
-	yamlData, err := os.ReadFile(yamlPath)
+	yamlData, err := os.ReadFile(yamlPath) //nolint:gosec // path constructed from working directory + constant filename
 	if err == nil {
 		if schemaErrs := bundledef.ValidateSchema(yamlData); len(schemaErrs) > 0 {
 			parts := make([]string, 0, len(schemaErrs)+1)

--- a/cmd/musher/yank.go
+++ b/cmd/musher/yank.go
@@ -40,7 +40,7 @@ func runYank(cmd *cobra.Command, out *output.Writer, ref string) error {
 		return err
 	}
 
-	reason, _ := cmd.Flags().GetString("reason")
+	reason, _ := cmd.Flags().GetString("reason") //nolint:errcheck // flag registered by AddCommand, cannot fail
 
 	c, authErr := requireAuth()
 	if authErr != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,6 +2,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,7 +78,7 @@ func DeleteAPIKey(apiURL string) error {
 	fileErr = deleteCredentialsFile(apiURL)
 
 	if keyringErr != nil && fileErr != nil {
-		return fmt.Errorf("no stored credentials found")
+		return errors.New("no stored credentials found")
 	}
 
 	return nil
@@ -119,7 +120,7 @@ func readCredentialsFile(apiURL string) string {
 func writeCredentialsFile(apiURL, apiKey string) error {
 	path := credentialFilePath(apiURL)
 	if path == "" {
-		return fmt.Errorf("could not determine credential file path")
+		return errors.New("could not determine credential file path")
 	}
 
 	dir := filepath.Dir(path)
@@ -137,12 +138,12 @@ func writeCredentialsFile(apiURL, apiKey string) error {
 func deleteCredentialsFile(apiURL string) error {
 	path := credentialFilePath(apiURL)
 	if path == "" {
-		return fmt.Errorf("could not determine credential file path")
+		return errors.New("could not determine credential file path")
 	}
 
 	err := os.Remove(path)
 	if os.IsNotExist(err) {
-		return fmt.Errorf("credentials file not found")
+		return errors.New("credentials file not found")
 	}
 
 	if err != nil {

--- a/internal/bundledef/bundledef.go
+++ b/internal/bundledef/bundledef.go
@@ -60,7 +60,7 @@ var kindPrefixes = []struct {
 func Load(dir string) (*Def, error) {
 	path := filepath.Join(dir, FileName)
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from known directory + constant filename
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("bundle definition file not found: %s (run 'musher init' to create one)", path)
@@ -99,7 +99,7 @@ func Save(dir string, d *Def) error {
 func SetVisibility(dir, visibility string) error {
 	path := filepath.Join(dir, FileName)
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from known directory + constant filename
 	if err != nil {
 		return fmt.Errorf("read bundle definition: %w", err)
 	}
@@ -244,8 +244,8 @@ func (d *Def) ValidateAssets(bundleRoot string) error {
 				continue
 			}
 
-			absRoot, _ := filepath.Abs(bundleRoot)
-			absTarget, _ := filepath.Abs(target)
+			absRoot, _ := filepath.Abs(bundleRoot) //nolint:errcheck // best-effort path resolution
+			absTarget, _ := filepath.Abs(target)   //nolint:errcheck // best-effort path resolution
 
 			if !strings.HasPrefix(absTarget, absRoot+string(filepath.Separator)) {
 				errs = append(errs, fmt.Sprintf("asset %q: symlink escapes bundle root: %s", asset.ID, asset.Src))
@@ -267,14 +267,14 @@ func (d *Def) ValidateAssets(bundleRoot string) error {
 	if d.Readme != "" {
 		readmePath := filepath.Join(bundleRoot, d.Readme)
 		if _, err := os.Stat(readmePath); err != nil {
-			errs = append(errs, fmt.Sprintf("readme file not found: %s", d.Readme))
+			errs = append(errs, "readme file not found: "+d.Readme)
 		}
 	}
 
 	if d.LicenseFile != "" {
 		licensePath := filepath.Join(bundleRoot, d.LicenseFile)
 		if _, err := os.Stat(licensePath); err != nil {
-			errs = append(errs, fmt.Sprintf("license file not found: %s", d.LicenseFile))
+			errs = append(errs, "license file not found: "+d.LicenseFile)
 		}
 	}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,6 +9,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -203,11 +204,11 @@ func (c *Client) ValidateKeyWithMeta(ctx context.Context) (*Identity, *ResponseM
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, meta, fmt.Errorf("invalid or expired API key")
+		return nil, meta, errors.New("invalid or expired API key")
 	}
 
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, meta, fmt.Errorf("API key does not have runner permissions")
+		return nil, meta, errors.New("API key does not have runner permissions")
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -250,11 +251,11 @@ func (c *Client) GetPublisherIdentityWithMeta(ctx context.Context) (*PublisherId
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, meta, fmt.Errorf("invalid or expired API key")
+		return nil, meta, errors.New("invalid or expired API key")
 	}
 
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, meta, fmt.Errorf("API key does not have publisher permissions")
+		return nil, meta, errors.New("API key does not have publisher permissions")
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/client/client_hub.go
+++ b/internal/client/client_hub.go
@@ -3,9 +3,11 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"strconv"
 	"time"
 )
 
@@ -85,7 +87,7 @@ type NamespaceHandle struct {
 }
 
 // ErrEndpointNotAvailable indicates the API endpoint is not yet deployed.
-var ErrEndpointNotAvailable = fmt.Errorf("endpoint not available")
+var ErrEndpointNotAvailable = errors.New("endpoint not available")
 
 // SearchHubBundles searches for bundles in the hub (public, no auth required).
 func (c *Client) SearchHubBundles(ctx context.Context, query, bundleType, sort string, limit int, cursor string) (*HubSearchResponse, error) {
@@ -112,7 +114,7 @@ func (c *Client) SearchHubBundles(ctx context.Context, query, bundleType, sort s
 	}
 
 	if limit > 0 {
-		params.Set("limit", fmt.Sprintf("%d", limit))
+		params.Set("limit", strconv.Itoa(limit))
 	}
 
 	if cursor != "" {
@@ -190,7 +192,7 @@ func (c *Client) ListPublisherBundles(ctx context.Context, publisherHandle strin
 	params := endpoint.Query()
 
 	if limit > 0 {
-		params.Set("limit", fmt.Sprintf("%d", limit))
+		params.Set("limit", strconv.Itoa(limit))
 	}
 
 	if cursor != "" {

--- a/internal/client/probe.go
+++ b/internal/client/probe.go
@@ -15,6 +15,8 @@ import (
 	"github.com/musher-dev/musher-cli/internal/safeio"
 )
 
+const tlsCertError = "TLS certificate error"
+
 const probeTimeout = 3 * time.Second
 
 // ProbeResult holds the outcome of a lightweight API health probe.
@@ -160,12 +162,12 @@ func summarizeNetworkError(err error) string {
 
 	var certErr *x509.UnknownAuthorityError
 	if errors.As(err, &certErr) {
-		return "TLS certificate error"
+		return tlsCertError
 	}
 
 	var certHostErr *x509.HostnameError
 	if errors.As(err, &certHostErr) {
-		return "TLS certificate error"
+		return tlsCertError
 	}
 
 	// Fall back to string matching for common patterns.
@@ -176,7 +178,7 @@ func summarizeNetworkError(err error) string {
 	case strings.Contains(lower, "connection refused"):
 		return "connection refused"
 	case strings.Contains(lower, "certificate"):
-		return "TLS certificate error"
+		return tlsCertError
 	case strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded"):
 		return "connection timed out"
 	case strings.Contains(lower, "no such host"):

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -175,14 +175,14 @@ func checkDirectoryStructure(context.Context) Result {
 			}
 		}
 
-		_ = f.Close()
-		_ = os.Remove(f.Name())
+		_ = f.Close()           //nolint:errcheck // best-effort cleanup
+		_ = os.Remove(f.Name()) //nolint:errcheck // best-effort cleanup
 	}
 
 	if len(missing) > 0 {
 		return Result{
 			Status:  StatusWarn,
-			Message: fmt.Sprintf("Missing directories: %s", strings.Join(missing, ", ")),
+			Message: "Missing directories: " + strings.Join(missing, ", "),
 			Detail:  "Created on first use by any musher command",
 		}
 	}
@@ -285,7 +285,7 @@ func checkCredentialsFile(context.Context) Result {
 		return Result{
 			Status:  StatusWarn,
 			Message: fmt.Sprintf("Credentials file too permissive (%04o)", mode),
-			Detail:  fmt.Sprintf("chmod 600 %s", credPath),
+			Detail:  "chmod 600 " + credPath,
 		}
 	}
 
@@ -417,7 +417,7 @@ func checkProxyEnvironment(context.Context) Result {
 
 	return Result{
 		Status:  StatusWarn,
-		Message: fmt.Sprintf("Proxy variables detected: %s", strings.Join(active, ", ")),
+		Message: "Proxy variables detected: " + strings.Join(active, ", "),
 		Detail:  "If requests fail with TLS errors, configure MUSHER_NETWORK_CA_CERT_FILE with your corporate proxy CA bundle",
 	}
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -170,7 +170,7 @@ func APIKeyEmpty() *CLIError {
 // ConfigFailed returns an error for configuration save failures.
 func ConfigFailed(operation string, cause error) *CLIError {
 	return enrichFromCause(&CLIError{
-		Message: fmt.Sprintf("Failed to %s", operation),
+		Message: "Failed to " + operation,
 		Hint:    "Check file permissions for your Musher config directory or run 'musher doctor'",
 		Cause:   cause,
 		Code:    ExitConfig,
@@ -207,7 +207,7 @@ func VersionConflict(versionRef string, cause error) *CLIError {
 // ValidateFailed returns an error for validation failures.
 func ValidateFailed(msg string) *CLIError {
 	return &CLIError{
-		Message: fmt.Sprintf("Validation failed: %s", msg),
+		Message: "Validation failed: " + msg,
 		Hint:    "Fix the issues above and run 'musher validate' again",
 		Code:    ExitGeneral,
 	}
@@ -216,7 +216,7 @@ func ValidateFailed(msg string) *CLIError {
 // InvalidBundleDef returns an error for invalid bundle definitions.
 func InvalidBundleDef(detail string) *CLIError {
 	return &CLIError{
-		Message: fmt.Sprintf("Invalid bundle definition: %s", detail),
+		Message: "Invalid bundle definition: " + detail,
 		Hint:    "Check musher.yaml for required fields",
 		Code:    ExitConfig,
 	}
@@ -225,7 +225,7 @@ func InvalidBundleDef(detail string) *CLIError {
 // YankFailed returns an error for yank failures.
 func YankFailed(version string, cause error) *CLIError {
 	return enrichFromCause(&CLIError{
-		Message: fmt.Sprintf("Failed to yank version %s", version),
+		Message: "Failed to yank version " + version,
 		Hint:    "Check the version exists and you have namespace access. Yanked versions are hidden from search/install but remain fetchable by digest",
 		Cause:   cause,
 		Code:    ExitGeneral,
@@ -235,7 +235,7 @@ func YankFailed(version string, cause error) *CLIError {
 // UnyankFailed returns an error for unyank failures.
 func UnyankFailed(version string, cause error) *CLIError {
 	return enrichFromCause(&CLIError{
-		Message: fmt.Sprintf("Failed to unyank version %s", version),
+		Message: "Failed to unyank version " + version,
 		Hint:    "Check the version exists, is currently yanked, and you have namespace access",
 		Cause:   cause,
 		Code:    ExitGeneral,

--- a/internal/observability/logging.go
+++ b/internal/observability/logging.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -142,7 +143,7 @@ func NewLogger(cfg *Config) (*slog.Logger, func() error, error) {
 func openLogFile(path string) (*os.File, error) {
 	cleanPath := strings.TrimSpace(path)
 	if cleanPath == "" {
-		return nil, fmt.Errorf("log file path cannot be empty")
+		return nil, errors.New("log file path cannot be empty")
 	}
 
 	if mkErr := os.MkdirAll(filepath.Dir(cleanPath), 0o700); mkErr != nil {
@@ -197,7 +198,7 @@ func rotateLogFile(path string, maxBytes int64, maxBackups int) error {
 		}
 	}
 
-	firstBackup := fmt.Sprintf("%s.1", path)
+	firstBackup := path + ".1"
 	if err := os.Rename(path, firstBackup); err != nil {
 		return fmt.Errorf("rotate current log to backup: %w", err)
 	}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,6 +1,7 @@
 package paths
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -27,7 +28,7 @@ func resolveRoot(brandedEnv, musherHomeSuffix, xdgEnv string, osFn func() (strin
 
 	if musherHome := os.Getenv("MUSHER_HOME"); musherHome != "" {
 		if !filepath.IsAbs(musherHome) {
-			return "", fmt.Errorf("MUSHER_HOME must be an absolute path")
+			return "", errors.New("MUSHER_HOME must be an absolute path")
 		}
 
 		return filepath.Join(musherHome, musherHomeSuffix), nil
@@ -51,7 +52,7 @@ func resolveRoot(brandedEnv, musherHomeSuffix, xdgEnv string, osFn func() (strin
 		return "", err
 	}
 
-	return "", fmt.Errorf("resolve user home directory")
+	return "", errors.New("resolve user home directory")
 }
 
 func configRoot() (string, error) {
@@ -60,7 +61,7 @@ func configRoot() (string, error) {
 
 func dataRoot() (string, error) {
 	noOSDefault := func() (string, error) {
-		return "", fmt.Errorf("no OS data directory function")
+		return "", errors.New("no OS data directory function")
 	}
 
 	return resolveRoot("MUSHER_DATA_HOME", "data", "XDG_DATA_HOME", noOSDefault, filepath.Join(".local", "share"))
@@ -68,7 +69,7 @@ func dataRoot() (string, error) {
 
 func stateRoot() (string, error) {
 	noOSDefault := func() (string, error) {
-		return "", fmt.Errorf("no OS state directory function")
+		return "", errors.New("no OS state directory function")
 	}
 
 	return resolveRoot("MUSHER_STATE_HOME", "state", "XDG_STATE_HOME", noOSDefault, filepath.Join(".local", "state"))
@@ -102,7 +103,7 @@ func CacheRoot() (string, error) {
 func RuntimeRoot() (string, error) {
 	if branded := os.Getenv("MUSHER_RUNTIME_DIR"); branded != "" {
 		if !filepath.IsAbs(branded) {
-			return "", fmt.Errorf("MUSHER_RUNTIME_DIR must be an absolute path")
+			return "", errors.New("MUSHER_RUNTIME_DIR must be an absolute path")
 		}
 
 		return filepath.Clean(branded), nil
@@ -110,7 +111,7 @@ func RuntimeRoot() (string, error) {
 
 	if musherHome := os.Getenv("MUSHER_HOME"); musherHome != "" {
 		if !filepath.IsAbs(musherHome) {
-			return "", fmt.Errorf("MUSHER_HOME must be an absolute path")
+			return "", errors.New("MUSHER_HOME must be an absolute path")
 		}
 
 		return filepath.Join(musherHome, "run"), nil

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -3,6 +3,7 @@ package prompt
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -64,44 +65,44 @@ func (p *Prompter) Password(prompt string) (string, error) {
 		return "", fmt.Errorf("failed to set raw mode: %w", err)
 	}
 
-	defer func() { _ = term.Restore(stdinFd, oldState) }()
+	defer func() { _ = term.Restore(stdinFd, oldState) }() //nolint:errcheck // best-effort terminal restore
 
 	var (
 		buf []byte
-		b   [1]byte
+		key [1]byte
 	)
 
 	for {
-		_, err := os.Stdin.Read(b[:])
+		_, err := os.Stdin.Read(key[:])
 		if err != nil {
 			p.out.Println()
 			return "", fmt.Errorf("failed to read input: %w", err)
 		}
 
 		switch {
-		case b[0] == '\r' || b[0] == '\n':
-			_ = term.Restore(stdinFd, oldState)
+		case key[0] == '\r' || key[0] == '\n':
+			_ = term.Restore(stdinFd, oldState) //nolint:errcheck // best-effort terminal restore
 
 			p.out.Println()
 
 			return string(buf), nil
-		case b[0] == 0x03: // Ctrl+C
-			_ = term.Restore(stdinFd, oldState)
+		case key[0] == 0x03: // Ctrl+C
+			_ = term.Restore(stdinFd, oldState) //nolint:errcheck // best-effort terminal restore
 
 			p.out.Println()
 
-			proc, _ := os.FindProcess(os.Getpid())
-			_ = proc.Signal(os.Interrupt)
+			proc, _ := os.FindProcess(os.Getpid()) //nolint:errcheck // best-effort signal delivery
+			_ = proc.Signal(os.Interrupt)          //nolint:errcheck // best-effort signal delivery
 
-			return "", fmt.Errorf("interrupted")
-		case b[0] == 127 || b[0] == 0x08: // Backspace / Delete
+			return "", errors.New("interrupted")
+		case key[0] == 127 || key[0] == 0x08: // Backspace / Delete
 			if len(buf) > 0 {
 				buf = buf[:len(buf)-1]
 
 				p.out.Print("\b \b")
 			}
-		case b[0] >= 32: // Printable character
-			buf = append(buf, b[0])
+		case key[0] >= 32: // Printable character
+			buf = append(buf, key[0])
 
 			p.out.Print("*")
 		}

--- a/internal/safeio/safeio.go
+++ b/internal/safeio/safeio.go
@@ -10,7 +10,7 @@ import (
 
 // ReadFile centralizes trusted-path reads.
 func ReadFile(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // trusted path wrapper, callers validate input
 	if err != nil {
 		return nil, fmt.Errorf("read file: %w", err)
 	}
@@ -52,7 +52,7 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 
 // Open centralizes trusted-path opens.
 func Open(path string) (*os.File, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(path) //nolint:gosec // trusted path wrapper, callers validate input
 	if err != nil {
 		return nil, fmt.Errorf("open file: %w", err)
 	}
@@ -62,7 +62,7 @@ func Open(path string) (*os.File, error) {
 
 // OpenFile centralizes trusted-path open flags.
 func OpenFile(path string, flag int, perm os.FileMode) (*os.File, error) {
-	file, err := os.OpenFile(path, flag, perm)
+	file, err := os.OpenFile(path, flag, perm) //nolint:gosec // trusted path wrapper, callers validate input
 	if err != nil {
 		return nil, fmt.Errorf("open file: %w", err)
 	}
@@ -82,33 +82,33 @@ func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
 	tmp := tmpFile.Name()
 
 	if _, writeErr := tmpFile.Write(data); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmp)
+		_ = tmpFile.Close() //nolint:errcheck // best-effort cleanup
+		_ = os.Remove(tmp)  //nolint:errcheck // best-effort cleanup
 
 		return fmt.Errorf("write temp file: %w", writeErr)
 	}
 
 	if chmodErr := os.Chmod(tmp, perm); chmodErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmp)
+		_ = tmpFile.Close() //nolint:errcheck // best-effort cleanup
+		_ = os.Remove(tmp)  //nolint:errcheck // best-effort cleanup
 
 		return fmt.Errorf("chmod temp file: %w", chmodErr)
 	}
 
 	if closeErr := tmpFile.Close(); closeErr != nil {
-		_ = os.Remove(tmp)
+		_ = os.Remove(tmp) //nolint:errcheck // best-effort cleanup
 		return fmt.Errorf("close temp file: %w", closeErr)
 	}
 
 	if renameErr := os.Rename(tmp, path); renameErr != nil {
 		// Fallback for Windows: remove dest then retry rename.
 		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
-			_ = os.Remove(tmp)
+			_ = os.Remove(tmp) //nolint:errcheck // best-effort cleanup
 			return fmt.Errorf("remove existing file: %w", removeErr)
 		}
 
 		if retryErr := os.Rename(tmp, path); retryErr != nil {
-			_ = os.Remove(tmp)
+			_ = os.Remove(tmp) //nolint:errcheck // best-effort cleanup
 			return fmt.Errorf("replace file: %w", retryErr)
 		}
 	}

--- a/internal/skills/validate.go
+++ b/internal/skills/validate.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,19 +28,19 @@ type frontmatter struct {
 // This is used during import discovery where skills live in source directories
 // whose names may not match the skill name.
 func ParseFrontmatter(path string) (name, description string, err error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path from validated bundle assets
 	if err != nil {
 		return "", "", fmt.Errorf("read skill file: %w", err)
 	}
 
 	raw := string(data)
 	if !strings.HasPrefix(raw, "---\n") {
-		return "", "", fmt.Errorf("missing YAML frontmatter")
+		return "", "", errors.New("missing YAML frontmatter")
 	}
 
 	parts := strings.SplitN(raw, "\n---\n", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("frontmatter must be closed with '---'")
+		return "", "", errors.New("frontmatter must be closed with '---'")
 	}
 
 	var matter frontmatter
@@ -48,7 +49,7 @@ func ParseFrontmatter(path string) (name, description string, err error) {
 	}
 
 	if matter.Name == "" {
-		return "", "", fmt.Errorf("name is required in frontmatter")
+		return "", "", errors.New("name is required in frontmatter")
 	}
 
 	if !skillNamePattern.MatchString(matter.Name) {
@@ -60,19 +61,19 @@ func ParseFrontmatter(path string) (name, description string, err error) {
 
 // ValidateFile validates a SKILL.md file against the Agent Skills spec.
 func ValidateFile(path string) error {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path from validated bundle assets
 	if err != nil {
 		return fmt.Errorf("read skill file: %w", err)
 	}
 
 	raw := string(data)
 	if !strings.HasPrefix(raw, "---\n") {
-		return fmt.Errorf("missing YAML frontmatter")
+		return errors.New("missing YAML frontmatter")
 	}
 
 	parts := strings.SplitN(raw, "\n---\n", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("frontmatter must be closed with '---'")
+		return errors.New("frontmatter must be closed with '---'")
 	}
 
 	var rawFields map[string]any

--- a/internal/update/agent.go
+++ b/internal/update/agent.go
@@ -2,7 +2,7 @@ package update
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 	"time"
 
@@ -16,8 +16,10 @@ type AgentConfig struct {
 	AutoApply      bool
 }
 
+const blockedReasonManagedInstall = "managed_install"
+
 // errApplyBlocked indicates a staged apply did not succeed (state was saved).
-var errApplyBlocked = fmt.Errorf("staged apply did not succeed")
+var errApplyBlocked = errors.New("staged apply did not succeed")
 
 // RunAgent performs a single background update tick.
 func RunAgent(cfg AgentConfig) error {
@@ -43,8 +45,8 @@ func RunAgent(cfg AgentConfig) error {
 
 		allowedBySource := AutoApplyAllowed(source)
 		if !allowedBySource {
-			state.AutoApplyBlockedReason = "managed_install"
-		} else if state.AutoApplyBlockedReason == "managed_install" {
+			state.AutoApplyBlockedReason = blockedReasonManagedInstall
+		} else if state.AutoApplyBlockedReason == blockedReasonManagedInstall {
 			// Source changed from managed to standalone — clear stale reason.
 			state.AutoApplyBlockedReason = ""
 		}
@@ -91,7 +93,7 @@ func RunAgent(cfg AgentConfig) error {
 			if !cfg.AutoApply {
 				state.AutoApplyBlockedReason = "auto_apply_disabled"
 			} else if !allowedBySource {
-				state.AutoApplyBlockedReason = "managed_install"
+				state.AutoApplyBlockedReason = blockedReasonManagedInstall
 			}
 		} else {
 			state.ClearStaged()
@@ -104,14 +106,14 @@ func RunAgent(cfg AgentConfig) error {
 
 func applyStaged(state *State, execPath string) error {
 	if execPath == "" {
-		return fmt.Errorf("executable path unavailable")
+		return errors.New("executable path unavailable")
 	}
 
 	if NeedsElevation(execPath) {
 		state.LastApplyAttemptAt = time.Now()
 		state.LastApplyError = "background apply requires elevated permissions"
 		state.AutoApplyBlockedReason = "elevation_required"
-		_ = SaveState(state)
+		_ = SaveState(state) //nolint:errcheck // best-effort state persistence
 
 		return errApplyBlocked
 	}
@@ -124,7 +126,7 @@ func applyStaged(state *State, execPath string) error {
 		state.LastApplyAttemptAt = time.Now()
 		state.LastApplyError = err.Error()
 		state.AutoApplyBlockedReason = "apply_error"
-		_ = SaveState(state)
+		_ = SaveState(state) //nolint:errcheck // best-effort state persistence
 
 		return errApplyBlocked
 	}
@@ -135,7 +137,7 @@ func applyStaged(state *State, execPath string) error {
 	if err != nil {
 		state.LastApplyError = err.Error()
 		state.AutoApplyBlockedReason = "apply_error"
-		_ = SaveState(state)
+		_ = SaveState(state) //nolint:errcheck // best-effort state persistence
 
 		return errApplyBlocked
 	}

--- a/internal/update/lock.go
+++ b/internal/update/lock.go
@@ -45,7 +45,7 @@ func WithAgentLock(runFn func() error) error {
 		return nil
 	}
 
-	defer func() { _ = os.Remove(path) }()
+	defer func() { _ = os.Remove(path) }() //nolint:errcheck // best-effort cleanup
 
 	return runFn()
 }
@@ -53,7 +53,7 @@ func WithAgentLock(runFn func() error) error {
 func tryAcquire(path string) (bool, error) {
 	file, err := safeio.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { _ = file.Close() }() //nolint:errcheck // best-effort cleanup
 
 		_, _ = fmt.Fprintf(file, "pid=%d time=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
 

--- a/internal/update/sudo.go
+++ b/internal/update/sudo.go
@@ -3,6 +3,7 @@
 package update
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,8 +21,8 @@ func NeedsElevation(binaryPath string) bool {
 		return true
 	}
 
-	_ = f.Close()
-	_ = os.Remove(f.Name())
+	_ = f.Close()           //nolint:errcheck // best-effort cleanup
+	_ = os.Remove(f.Name()) //nolint:errcheck // best-effort cleanup
 
 	return false
 }
@@ -31,7 +32,7 @@ func NeedsElevation(binaryPath string) bool {
 func ReExecWithSudo() error {
 	sudoPath, err := exec.LookPath("sudo")
 	if err != nil {
-		return fmt.Errorf("sudo not found in PATH; run this command with elevated permissions manually")
+		return errors.New("sudo not found in PATH; run this command with elevated permissions manually")
 	}
 
 	execPath, err := os.Executable()


### PR DESCRIPTION
## Summary

- **Expand golangci-lint config** with 10 new linters (intrange, reassign, containedctx, makezero, mirror, perfsprint, sloglint, exhaustive, goconst, nakedret) and broader revive rules
- **Fix all resulting lint findings** across 27 files: `errors.New` for static strings, `strconv.Itoa` for integers, string concatenation over `fmt.Sprintf`, descriptive variable names, extracted constants, and targeted `//nolint` directives for intentional error discards
- **Update README and CLAUDE.md** to reflect host-scoped credentials, two-step publishing model, and current project structure

## Test plan

- [ ] `task check` passes (fmt + lint + vuln + test)
- [ ] `task build` produces a working binary
- [ ] Verify no behavioral changes — all modifications are lint fixes, constant extractions, and documentation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)