### PR TITLE
feat: add pull command to download bundles from registry

### DIFF
--- a/cmd/musher/hub.go
+++ b/cmd/musher/hub.go
@@ -55,3 +55,28 @@ func parseBundleRef(ref string) (namespace, slug string, err error) {
 
 	return namespace, slug, nil
 }
+
+// parseBundleRefOptionalVersion parses "namespace/slug" or "namespace/slug:version".
+// If no version is provided, version is returned as "".
+func parseBundleRefOptionalVersion(ref string) (namespace, slug, version string, err error) {
+	nsSlug := ref
+	if colonIdx := strings.LastIndex(ref, ":"); colonIdx > 0 {
+		nsSlug = ref[:colonIdx]
+		version = ref[colonIdx+1:]
+
+		if version == "" {
+			return "", "", "", &clierrors.CLIError{
+				Message: fmt.Sprintf("empty version in ref %q", ref),
+				Hint:    "Use <namespace/slug> or <namespace/slug:version>",
+				Code:    clierrors.ExitUsage,
+			}
+		}
+	}
+
+	namespace, slug, ok := strings.Cut(nsSlug, "/")
+	if !ok || namespace == "" || slug == "" {
+		return "", "", "", clierrors.New(clierrors.ExitUsage, "ref must be in the format <namespace/slug> or <namespace/slug:version>")
+	}
+
+	return namespace, slug, version, nil
+}

--- a/cmd/musher/pull.go
+++ b/cmd/musher/pull.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/musher-dev/musher-cli/internal/client"
+	clierrors "github.com/musher-dev/musher-cli/internal/errors"
+	"github.com/musher-dev/musher-cli/internal/output"
+	"github.com/musher-dev/musher-cli/internal/paths"
+	"github.com/musher-dev/musher-cli/internal/safeio"
+)
+
+func newPullCmd() *cobra.Command {
+	var (
+		outputDir string
+		force     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "pull <namespace/slug[:version]>",
+		Short: "Download a bundle from the registry",
+		Long: `Download a bundle version from the Musher registry.
+
+By default, bundles are cached in ~/.cache/musher/bundles/<namespace>/<slug>/<version>/.
+Use --output-dir to extract to a specific directory instead (flat layout, no symlinks).
+
+If no version is specified, the latest version is downloaded.
+
+Authentication is attempted first; public bundles can be pulled without credentials.`,
+		Example: `  musher pull acme/my-bundle
+  musher pull acme/my-bundle:1.0.0
+  musher pull acme/my-bundle:1.0.0 --output-dir ./bundles/
+  musher pull acme/my-bundle --json`,
+		Args: requireOneArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := output.FromContext(cmd.Context())
+			return runPull(cmd, out, args[0], outputDir, force)
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputDir, "output-dir", "o", "",
+		"Extract bundle to this directory instead of the default cache")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Re-download even if already cached")
+
+	return cmd
+}
+
+// pullResult is the JSON output for the pull command.
+type pullResult struct {
+	Namespace  string `json:"namespace"`
+	Slug       string `json:"slug"`
+	Version    string `json:"version"`
+	Dir        string `json:"dir"`
+	Cached     bool   `json:"cached"`
+	AssetCount int    `json:"assetCount,omitempty"`
+}
+
+func runPull(cmd *cobra.Command, out *output.Writer, ref, outputDir string, force bool) error {
+	ctx := cmd.Context()
+
+	namespace, slug, bundleVersion, err := parseBundleRefOptionalVersion(ref)
+	if err != nil {
+		return err
+	}
+
+	// Resolve version if not specified.
+	if bundleVersion == "" {
+		resolved, resolveErr := resolveLatestVersion(cmd, out, namespace, slug)
+		if resolveErr != nil {
+			return resolveErr
+		}
+
+		bundleVersion = resolved
+	}
+
+	versionRef := namespace + "/" + slug + ":" + bundleVersion
+
+	// Determine target directory.
+	targetDir := outputDir
+	if targetDir == "" {
+		cacheDir, cacheErr := paths.BundleCacheDir(namespace, slug, bundleVersion)
+		if cacheErr != nil {
+			return clierrors.Wrap(clierrors.ExitConfig, "Failed to determine cache directory", cacheErr)
+		}
+
+		targetDir = cacheDir
+
+		// Check if already cached (skip when --force or --output-dir is set).
+		if !force {
+			if isCached(targetDir) {
+				if out.JSON {
+					if jsonErr := out.PrintJSON(pullResult{
+						Namespace: namespace,
+						Slug:      slug,
+						Version:   bundleVersion,
+						Dir:       targetDir,
+						Cached:    true,
+					}); jsonErr != nil {
+						return fmt.Errorf("print JSON: %w", jsonErr)
+					}
+
+					return nil
+				}
+
+				out.Success("Already cached: %s", versionRef)
+				out.Muted("  %s", targetDir)
+
+				return nil
+			}
+		}
+	}
+
+	// Try authenticated client first, fall back to public.
+	_, apiClient, authErr := newAPIClient()
+	usePublic := authErr != nil
+
+	if usePublic {
+		cfg := configForPublicClient()
+		apiClient = newPublicAPIClient(cfg)
+	}
+
+	// Pull the bundle.
+	spin := out.Spinner("Pulling " + versionRef)
+	spin.Start()
+
+	var bundle *client.PullBundleResponse
+
+	if usePublic {
+		bundle, err = apiClient.PullPublicBundleVersion(ctx, namespace, slug, bundleVersion)
+	} else {
+		bundle, err = apiClient.PullBundleVersion(ctx, namespace, slug, bundleVersion)
+	}
+
+	if err != nil {
+		spin.StopWithFailure("Pull failed")
+		return clierrors.PullFailed(err)
+	}
+
+	spin.StopWithSuccess("Pulled " + versionRef)
+
+	// Write assets to target directory.
+	if mkdirErr := safeio.MkdirAll(targetDir, 0o755); mkdirErr != nil {
+		return clierrors.Wrap(clierrors.ExitGeneral, "Failed to create output directory", mkdirErr)
+	}
+
+	for _, asset := range bundle.Assets {
+		assetPath := filepath.Join(targetDir, asset.LogicalPath)
+		assetDir := filepath.Dir(assetPath)
+
+		if mkErr := safeio.MkdirAll(assetDir, 0o755); mkErr != nil {
+			return clierrors.Wrap(clierrors.ExitGeneral,
+				"Failed to create directory for asset "+asset.LogicalPath, mkErr)
+		}
+
+		if writeErr := safeio.WriteFileAtomic(assetPath, []byte(asset.ContentText), 0o644); writeErr != nil {
+			return clierrors.Wrap(clierrors.ExitGeneral,
+				"Failed to write asset "+asset.LogicalPath, writeErr)
+		}
+	}
+
+	if out.JSON {
+		if jsonErr := out.PrintJSON(pullResult{
+			Namespace:  namespace,
+			Slug:       slug,
+			Version:    bundleVersion,
+			Dir:        targetDir,
+			AssetCount: len(bundle.Assets),
+		}); jsonErr != nil {
+			return fmt.Errorf("print JSON: %w", jsonErr)
+		}
+
+		return nil
+	}
+
+	out.Success("Wrote %d asset(s) to %s", len(bundle.Assets), targetDir)
+
+	return nil
+}
+
+// isCached returns true if the directory exists and contains at least one entry.
+func isCached(dir string) bool {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	entries, err := os.ReadDir(dir)
+
+	return err == nil && len(entries) > 0
+}
+
+// resolveLatestVersion fetches bundle detail to determine the latest version.
+func resolveLatestVersion(cmd *cobra.Command, out *output.Writer, namespace, slug string) (string, error) {
+	_, apiClient, authErr := newAPIClient()
+	if authErr != nil {
+		cfg := configForPublicClient()
+		apiClient = newPublicAPIClient(cfg)
+	}
+
+	spin := out.Spinner("Resolving latest version of " + namespace + "/" + slug)
+	spin.Start()
+
+	detail, err := apiClient.GetHubBundleDetail(cmd.Context(), namespace, slug)
+	if err != nil {
+		spin.StopWithFailure("Failed to resolve version")
+
+		return "", clierrors.Wrap(clierrors.ExitGeneral,
+			"Failed to resolve latest version for "+namespace+"/"+slug, err)
+	}
+
+	if detail.LatestVersion == "" {
+		spin.StopWithFailure("No versions available")
+
+		return "", clierrors.New(clierrors.ExitGeneral,
+			"Bundle "+namespace+"/"+slug+" has no published versions")
+	}
+
+	spin.StopWithSuccess("Resolved " + namespace + "/" + slug + ":" + detail.LatestVersion)
+
+	return detail.LatestVersion, nil
+}

--- a/cmd/musher/pull_test.go
+++ b/cmd/musher/pull_test.go
@@ -1,0 +1,113 @@
+package main
+
+import "testing"
+
+func TestParseBundleRefOptionalVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		ref       string
+		wantNS    string
+		wantSlug  string
+		wantVer   string
+		wantError bool
+	}{
+		{
+			name:     "namespace and slug only",
+			ref:      "acme/my-bundle",
+			wantNS:   "acme",
+			wantSlug: "my-bundle",
+			wantVer:  "",
+		},
+		{
+			name:     "namespace slug and version",
+			ref:      "acme/my-bundle:1.0.0",
+			wantNS:   "acme",
+			wantSlug: "my-bundle",
+			wantVer:  "1.0.0",
+		},
+		{
+			name:     "version with pre-release",
+			ref:      "acme/my-bundle:2.0.0-beta.1",
+			wantNS:   "acme",
+			wantSlug: "my-bundle",
+			wantVer:  "2.0.0-beta.1",
+		},
+		{
+			name:      "empty version after colon",
+			ref:       "acme/my-bundle:",
+			wantError: true,
+		},
+		{
+			name:      "no slash",
+			ref:       "my-bundle",
+			wantError: true,
+		},
+		{
+			name:      "empty namespace",
+			ref:       "/my-bundle",
+			wantError: true,
+		},
+		{
+			name:      "empty slug",
+			ref:       "acme/",
+			wantError: true,
+		},
+		{
+			name:      "empty string",
+			ref:       "",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, slug, ver, err := parseBundleRefOptionalVersion(tt.ref)
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error for ref %q, got nil", tt.ref)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for ref %q: %v", tt.ref, err)
+			}
+
+			if ns != tt.wantNS {
+				t.Errorf("namespace = %q, want %q", ns, tt.wantNS)
+			}
+
+			if slug != tt.wantSlug {
+				t.Errorf("slug = %q, want %q", slug, tt.wantSlug)
+			}
+
+			if ver != tt.wantVer {
+				t.Errorf("version = %q, want %q", ver, tt.wantVer)
+			}
+		})
+	}
+}
+
+func TestPullCommandRegistered(t *testing.T) {
+	cmd := newPullCmd()
+
+	if cmd.Use != "pull <namespace/slug[:version]>" {
+		t.Fatalf("unexpected Use: %q", cmd.Use)
+	}
+
+	outputDirFlag := cmd.Flags().Lookup("output-dir")
+	if outputDirFlag == nil {
+		t.Fatal("expected --output-dir flag to be registered")
+	}
+
+	if outputDirFlag.Shorthand != "o" {
+		t.Errorf("output-dir shorthand = %q, want %q", outputDirFlag.Shorthand, "o")
+	}
+
+	forceFlag := cmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Fatal("expected --force flag to be registered")
+	}
+}

--- a/cmd/musher/root.go
+++ b/cmd/musher/root.go
@@ -162,6 +162,10 @@ func registerRootCommands(rootCmd *cobra.Command) {
 	pushCmd.GroupID = groupPublish
 	rootCmd.AddCommand(pushCmd)
 
+	pullCmd := newPullCmd()
+	pullCmd.GroupID = groupPublish
+	rootCmd.AddCommand(pullCmd)
+
 	yankCmd := newYankCmd()
 	yankCmd.GroupID = groupPublish
 	rootCmd.AddCommand(yankCmd)

--- a/internal/client/client_publish.go
+++ b/internal/client/client_publish.go
@@ -160,6 +160,98 @@ func (c *Client) GetMyNamespaces(ctx context.Context) ([]NamespaceHandle, error)
 	return identity.Namespaces, nil
 }
 
+// PullBundleAsset represents a single asset in a pull response.
+type PullBundleAsset struct {
+	LogicalPath string `json:"logicalPath"`
+	AssetType   string `json:"assetType"`
+	ContentText string `json:"contentText"`
+	MediaType   string `json:"mediaType,omitempty"`
+}
+
+// PullBundleResponse is the response from downloading a bundle version.
+type PullBundleResponse struct {
+	Namespace   string            `json:"namespace"`
+	Slug        string            `json:"slug"`
+	Version     string            `json:"version"`
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Assets      []PullBundleAsset `json:"manifest"`
+}
+
+// PullBundleVersion downloads a bundle version's definition and assets.
+//
+//nolint:dupl // intentionally parallel to PullPublicBundleVersion (different auth and endpoint)
+func (c *Client) PullBundleVersion(ctx context.Context, namespace, slug, version string) (*PullBundleResponse, error) {
+	path := fmt.Sprintf("/v1/namespaces/%s/bundles/%s/versions/%s:pull",
+		neturl.PathEscape(namespace),
+		neturl.PathEscape(slug),
+		neturl.PathEscape(version),
+	)
+
+	req, err := c.newRequest(ctx, "GET", c.baseURL+path, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.do(req, path)
+	if err != nil {
+		return nil, fmt.Errorf("pull bundle version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("bundle %s/%s:%s not found", namespace, slug, version)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, unexpectedStatus("pull bundle version", resp)
+	}
+
+	var result PullBundleResponse
+	if err := decodeJSON(resp.Body, &result, "failed to parse pull response"); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// PullPublicBundleVersion downloads a public bundle version (no auth required).
+//
+//nolint:dupl // intentionally parallel to PullBundleVersion (different auth and endpoint)
+func (c *Client) PullPublicBundleVersion(ctx context.Context, namespace, slug, version string) (*PullBundleResponse, error) {
+	path := fmt.Sprintf("/v1/hub/bundles/%s/%s/versions/%s:pull",
+		neturl.PathEscape(namespace),
+		neturl.PathEscape(slug),
+		neturl.PathEscape(version),
+	)
+
+	req, err := c.newPublicRequest(ctx, "GET", c.baseURL+path, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.do(req, path)
+	if err != nil {
+		return nil, fmt.Errorf("pull public bundle version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("bundle %s/%s:%s not found", namespace, slug, version)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, unexpectedStatus("pull public bundle version", resp)
+	}
+
+	var result PullBundleResponse
+	if err := decodeJSON(resp.Body, &result, "failed to parse pull response"); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // UnyankBundleVersion restores a previously yanked bundle version.
 func (c *Client) UnyankBundleVersion(ctx context.Context, namespace, bundle, version string) error {
 	path := fmt.Sprintf("/v1/namespaces/%s/bundles/%s/versions/%s:unyank",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -222,6 +222,22 @@ func InvalidBundleDef(detail string) *CLIError {
 	}
 }
 
+// PullFailed returns an error for bundle pull failures.
+func PullFailed(cause error) *CLIError {
+	hint := "Check the bundle reference and your credentials, then try again"
+
+	if containsAny(errorString(cause), "not found") {
+		hint = "Verify the namespace, slug, and version are correct"
+	}
+
+	return enrichFromCause(&CLIError{
+		Message: "Pull failed",
+		Hint:    hint,
+		Cause:   cause,
+		Code:    ExitGeneral,
+	})
+}
+
 // YankFailed returns an error for yank failures.
 func YankFailed(version string, cause error) *CLIError {
 	return enrichFromCause(&CLIError{

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -219,6 +219,16 @@ func CredentialFilePath(hostID string) (string, error) {
 	return filepath.Join(root, "credentials", hostID, "api-key"), nil
 }
 
+// BundleCacheDir returns the cache directory for a specific bundle version.
+func BundleCacheDir(namespace, slug, version string) (string, error) {
+	root, err := cacheRoot()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, "bundles", namespace, slug, version), nil
+}
+
 // OCIStoreDir returns the OCI store directory for Musher.
 func OCIStoreDir() (string, error) {
 	root, err := dataRoot()


### PR DESCRIPTION
## Summary

- Add `musher pull <namespace/slug[:version]>` command to download bundle assets from the Musher registry
- Support authenticated and public endpoints with automatic fallback when not logged in
- Implement XDG-based bundle caching (`~/.cache/musher/bundles/`) with `--force` flag to re-download
- Add automatic latest version resolution when version is omitted
- Use atomic file writes via `safeio` to prevent partial/corrupt assets

## Test plan

- [x] All existing tests pass (`task check`)
- [x] New unit tests for `parseBundleRefOptionalVersion` (happy + error paths)
- [x] New test verifying command registration and flags
- [ ] Manual: `musher pull <namespace/slug>` downloads to cache dir
- [ ] Manual: `musher pull <namespace/slug> -o ./out` downloads to custom dir
- [ ] Manual: `musher pull <namespace/slug> --force` re-downloads cached bundle
- [ ] Manual: `musher pull <namespace/slug> --json` outputs structured JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)