### PR TITLE
docs: add Windows installer and refresh README

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,3 +55,4 @@ release:
   name_template: "{{.Version}}"
   extra_files:
     - glob: install.sh
+    - glob: install.ps1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/musher-dev/brand/main/dist/logo/svg/musher-logo-lockup-horizontal-dark-transparent.svg" />
     <img alt="Musher CLI" src="https://raw.githubusercontent.com/musher-dev/brand/main/dist/logo/svg/musher-logo-lockup-horizontal-dark-transparent.svg" height="80" />
   </picture>
-  <h3>Publish agent bundles to the Musher registry.</h3>
+  <h3>Author, validate, and publish Musher bundles.</h3>
 
   <a href="https://github.com/musher-dev/musher-cli/actions/workflows/ci.yml"><img src="https://github.com/musher-dev/musher-cli/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
   <a href="https://github.com/musher-dev/musher-cli/releases"><img src="https://img.shields.io/github/v/release/musher-dev/musher-cli" alt="Release" /></a>
@@ -18,7 +18,9 @@
   </p>
 </div>
 
-Musher is the publishing companion to [Mush](https://github.com/musher-dev/mush) — while Mush loads and runs bundles locally, Musher handles creating, validating, and publishing them. Think `docker push` vs `docker run`.
+Musher is the CLI for bundle authors on [musher.dev](https://musher.dev). Use it to scaffold bundle projects, register assets, validate bundle definitions, publish immutable bundle versions to the Musher registry, and manage public Hub listings.
+
+Bundles published with Musher can be loaded and run locally with [Mush](https://github.com/musher-dev/mush) or consumed programmatically via the [Python SDK](https://github.com/musher-dev/python-sdk) and [TypeScript SDK](https://github.com/musher-dev/typescript-sdk).
 
 ## Install
 
@@ -28,43 +30,45 @@ Musher is the publishing companion to [Mush](https://github.com/musher-dev/mush)
 curl -fsSL https://get.musher.dev | sh
 ```
 
+**Windows (PowerShell):**
+
+```powershell
+irm https://get.musher.dev/install.ps1 | iex
+```
+
 **From source** (requires Go 1.26.1+):
 
 ```bash
 go install github.com/musher-dev/musher-cli/cmd/musher@latest
 ```
 
-**Windows:** Download the latest `.zip` from [GitHub Releases](https://github.com/musher-dev/musher-cli/releases) and add the binary to your `PATH`.
-
 ## Quick Start
 
-Authenticate with the Musher registry:
+Authenticate and check your identity:
 
 ```bash
 musher login
+musher whoami
 ```
 
-Initialize a new bundle project:
+**New bundle project:**
 
 ```bash
-musher init
-```
-
-This creates `musher.yaml`, `skills/<slug>/SKILL.md`, and `README.md`. Use `--empty` to create the definition file only.
-
-Validate your bundle definition:
-
-```bash
+musher init       # scaffolds musher.yaml, skill templates, README.md
 musher validate
-```
-
-Push the bundle to the registry:
-
-```bash
 musher push
 ```
 
-Optionally, list on the public Hub catalog:
+**Existing project:**
+
+```bash
+musher init --empty   # creates musher.yaml only
+musher add --all      # discovers and registers conventional assets
+musher validate
+musher push
+```
+
+Optionally, list on the public Hub:
 
 ```bash
 musher hub publish <namespace/slug>
@@ -72,12 +76,10 @@ musher hub publish <namespace/slug>
 
 ## Registry vs Hub
 
-Musher has a two-step publishing model:
+- **Registry** — Where versioned bundles live. Private by default. Every `musher push` creates an immutable, content-addressable version.
+- **Hub** — The public discovery layer at [hub.musher.dev](https://hub.musher.dev). A separate action (`musher hub publish` or `musher push --publish-to-hub`) creates a listing. Requires `description`, `readme`, and `license` or `licenseFile` in `musher.yaml`.
 
-1. **`musher push`** uploads your bundle to the **registry** (private by default).
-2. **`musher hub publish`** creates or updates a public **Hub catalog listing** for a pushed bundle.
-
-You can push bundles without listing them on the Hub. Hub publishing requires additional metadata: `description`, `readme`, and `license` or `licenseFile`.
+You can push bundles without listing them on the Hub.
 
 ## Core Concepts
 
@@ -85,17 +87,20 @@ You can push bundles without listing them on the Hub. Hub publishing requires ad
 - **Asset** — A single file within a bundle (e.g., a skill markdown file, a prompt template, an agent spec).
 - **Bundle definition** — The `musher.yaml` file that describes your bundle's metadata and assets.
 - **Namespace** — The publishing identity under which bundles are published (e.g., `acme/my-bundle`).
+- **Immutability** — Once a version is pushed, it cannot be changed or overwritten. Yanked versions are hidden from search but remain fetchable by content-addressable digest, so existing lockfiles continue to resolve.
 
 ## `musher.yaml` Bundle Definition
 
 **Minimal (private) bundle:**
 
 ```yaml
+name: My Skill Bundle
+description: A helpful coding skill
+
 namespace: acme
 slug: my-skill
 version: 1.0.0
-name: My Skill Bundle
-description: A helpful coding skill
+
 assets:
   - id: my-skill
     src: skills/my-skill/SKILL.md
@@ -104,11 +109,13 @@ assets:
 **Hub-ready (public) bundle:**
 
 ```yaml
+name: Team Code Review
+description: Consistent code review guidance for engineering teams
+
 namespace: acme
 slug: code-review
 version: 0.1.0
-name: Team Code Review
-description: Consistent code review guidance for engineering teams
+
 visibility: public
 readme: README.md
 licenseFile: LICENSE
@@ -116,6 +123,7 @@ repository: https://github.com/acme/code-review-bundle
 keywords:
   - code-review
   - engineering
+
 assets:
   - id: code-review
     src: skills/code-review/SKILL.md
@@ -138,10 +146,12 @@ assets:
 
 | Command | Description |
 |---------|-------------|
-| `musher init` | Scaffold a bundle project (`musher.yaml`, skill template, `README.md`). Use `--empty` for definition only |
+| `musher init` | Scaffold a bundle project. Use `--empty` for definition only |
+| `musher add [path...]` | Register assets in `musher.yaml`. Use `--all` to discover conventional assets |
 | `musher validate` | Validate bundle definition and assets |
-| `musher push` | Push the bundle to the registry |
-| `musher yank <ns/slug:version>` | Yank a published version |
+| `musher push` | Push bundle to the registry. Use `--publish-to-hub` to also create a Hub listing |
+| `musher pull <ns/slug[:version]>` | Download a bundle. Use `-o` to extract to a directory |
+| `musher yank <ns/slug:version>` | Yank a published version. Use `--reason` to record why |
 | `musher unyank <ns/slug:version>` | Restore a yanked version |
 
 ### Hub
@@ -187,6 +197,8 @@ All paths follow XDG conventions. Override with `MUSHER_CONFIG_HOME`, `MUSHER_DA
 | `--api-url` | Override the API endpoint |
 | `--api-key` | Provide an API key directly (overrides keyring) |
 | `--json` | Output results as JSON |
+| `--quiet` | Minimal output (for CI) |
+| `--no-color` | Disable colored output |
 | `--no-input` | Disable interactive prompts |
 
 ## Contributing

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,281 @@
+# Install script for Musher CLI
+# Usage: irm https://get.musher.dev/install.ps1 | iex
+#   or:  .\install.ps1 [-Version 0.3.2] [-InstallDir C:\path] [-Yes]
+#
+# Options:
+#   -Version VERSION   Install a specific version (default: latest)
+#   -InstallDir DIR    Install to DIR (default: $env:LOCALAPPDATA\musher\bin)
+#   -Yes               Skip confirmation prompts
+#   -Help              Show this help message
+
+param(
+    [string]$Version = "",
+    [string]$InstallDir = "",
+    [switch]$Yes,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "musher-dev/musher-cli"
+$Binary = "musher"
+$BaseUrl = "https://github.com/$Repo"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Write-Err {
+    param([string]$Message)
+    Write-Host "Error: $Message" -ForegroundColor Red
+    exit 1
+}
+
+function Write-Bold {
+    param([string]$Message)
+    if ($Host.UI.SupportsVirtualTerminal) {
+        Write-Host "`e[1m$Message`e[0m"
+    } else {
+        Write-Host $Message
+    }
+}
+
+function Write-Green {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Green
+}
+
+function Write-Yellow {
+    param([string]$Message)
+    Write-Host $Message -ForegroundColor Yellow
+}
+
+function Show-Usage {
+    Write-Host @"
+Install Musher CLI
+
+Usage:
+  install.ps1 [options]
+
+Options:
+  -Version VERSION   Install a specific version (default: latest)
+  -InstallDir DIR    Install to DIR (default: `$env:LOCALAPPDATA\musher\bin)
+  -Yes               Skip confirmation prompts
+  -Help              Show this help message
+
+Examples:
+  irm https://get.musher.dev/install.ps1 | iex
+  .\install.ps1 -Version 0.3.2
+  .\install.ps1 -InstallDir C:\tools\musher
+"@
+}
+
+# ── Platform detection ───────────────────────────────────────────────────────
+
+function Get-Arch {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { return "amd64" }
+        "ARM64" { return "arm64" }
+        default { Write-Err "Unsupported architecture: $arch" }
+    }
+}
+
+# ── Version resolution ───────────────────────────────────────────────────────
+
+function Resolve-LatestVersion {
+    try {
+        $response = Invoke-WebRequest -Uri "$BaseUrl/releases/latest" `
+            -MaximumRedirection 0 `
+            -ErrorAction SilentlyContinue `
+            -UseBasicParsing 2>$null
+    } catch {
+        $response = $_.Exception.Response
+    }
+
+    if ($null -eq $response) {
+        Write-Err "Failed to resolve latest version. Check $BaseUrl/releases"
+    }
+
+    $location = ""
+    if ($response.Headers -and $response.Headers["Location"]) {
+        $location = $response.Headers["Location"]
+        if ($location -is [array]) { $location = $location[0] }
+    }
+
+    if (-not $location) {
+        # PowerShell 5.1: try the final URL from a followed redirect
+        try {
+            $followed = Invoke-WebRequest -Uri "$BaseUrl/releases/latest" `
+                -UseBasicParsing -ErrorAction Stop
+            $location = $followed.BaseResponse.ResponseUri.AbsoluteUri
+            if (-not $location) {
+                $location = $followed.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+            }
+        } catch {
+            Write-Err "Failed to resolve latest version. Check $BaseUrl/releases"
+        }
+    }
+
+    if (-not $location) {
+        Write-Err "Failed to resolve latest version. Check $BaseUrl/releases"
+    }
+
+    $tag = $location.Split("/")[-1]
+    if (-not $tag) {
+        Write-Err "Could not parse version from redirect URL: $location"
+    }
+    return $tag
+}
+
+# ── Checksum verification ────────────────────────────────────────────────────
+
+function Test-Checksum {
+    param(
+        [string]$File,
+        [string]$ChecksumsFile,
+        [string]$ArchiveName
+    )
+
+    $checksums = Get-Content $ChecksumsFile
+    $expected = ""
+    foreach ($line in $checksums) {
+        $parts = $line -split '\s+'
+        if ($parts.Length -ge 2 -and $parts[1] -eq $ArchiveName) {
+            $expected = $parts[0]
+            break
+        }
+    }
+
+    if (-not $expected) {
+        Write-Err "Archive '$ArchiveName' not found in checksums file"
+    }
+
+    $actual = (Get-FileHash -Path $File -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected.ToLower()) {
+        Write-Err @"
+Checksum mismatch!
+  Expected: $expected
+  Actual:   $actual
+"@
+    }
+}
+
+# ── PATH helpers ─────────────────────────────────────────────────────────────
+
+function Test-InPath {
+    param([string]$Dir)
+    $paths = [Environment]::GetEnvironmentVariable("Path", "User") -split ";"
+    foreach ($p in $paths) {
+        if ($p.TrimEnd("\") -eq $Dir.TrimEnd("\")) { return $true }
+    }
+    return $false
+}
+
+function Add-ToPath {
+    param([string]$Dir)
+    $current = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($current) {
+        $newPath = "$current;$Dir"
+    } else {
+        $newPath = $Dir
+    }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+function Main {
+    if ($Help) {
+        Show-Usage
+        return
+    }
+
+    $Arch = Get-Arch
+    if (-not $InstallDir) {
+        $InstallDir = Join-Path $env:LOCALAPPDATA "musher\bin"
+    }
+
+    Write-Bold "Musher CLI Installer"
+    Write-Host ""
+
+    if ($Version) {
+        $Version = $Version.TrimStart("v")
+        $Tag = "v$Version"
+    } else {
+        Write-Host "Resolving latest version..."
+        $Tag = Resolve-LatestVersion
+        $Version = $Tag.TrimStart("v")
+    }
+
+    $ArchiveName = "${Binary}_${Version}_windows_${Arch}.zip"
+    $ArchiveUrl = "$BaseUrl/releases/download/$Tag/$ArchiveName"
+    $ChecksumsUrl = "$BaseUrl/releases/download/$Tag/checksums.txt"
+
+    Write-Host "  Version:  $Tag"
+    Write-Host "  Platform: windows/$Arch"
+    Write-Host "  Target:   $InstallDir\$Binary.exe"
+    Write-Host ""
+
+    if (-not $Yes -and [Environment]::UserInteractive) {
+        $reply = Read-Host "Proceed with installation? [Y/n]"
+        if ($reply -match "^[nN]") {
+            Write-Host "Aborted."
+            return
+        }
+    }
+
+    $TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "musher-install-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+    New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+    try {
+        Write-Host "Downloading $ArchiveName..."
+        Invoke-WebRequest -Uri $ArchiveUrl -OutFile (Join-Path $TmpDir $ArchiveName) -UseBasicParsing
+
+        Write-Host "Downloading checksums..."
+        Invoke-WebRequest -Uri $ChecksumsUrl -OutFile (Join-Path $TmpDir "checksums.txt") -UseBasicParsing
+
+        Write-Host "Verifying checksum..."
+        Test-Checksum -File (Join-Path $TmpDir $ArchiveName) `
+            -ChecksumsFile (Join-Path $TmpDir "checksums.txt") `
+            -ArchiveName $ArchiveName
+
+        Write-Host "Extracting..."
+        Expand-Archive -Path (Join-Path $TmpDir $ArchiveName) -DestinationPath $TmpDir -Force
+
+        if (-not (Test-Path $InstallDir)) {
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+        }
+        Copy-Item -Path (Join-Path $TmpDir "$Binary.exe") -Destination (Join-Path $InstallDir "$Binary.exe") -Force
+
+        Write-Host ""
+        Write-Green "Successfully installed musher $Tag to $InstallDir\$Binary.exe"
+        Write-Host ""
+
+        if (-not (Test-InPath $InstallDir)) {
+            Write-Yellow "Warning: $InstallDir is not in your PATH."
+            Write-Host ""
+
+            if (-not $Yes -and [Environment]::UserInteractive) {
+                $reply = Read-Host "Add $InstallDir to your user PATH? [Y/n]"
+                if ($reply -notmatch "^[nN]") {
+                    Add-ToPath $InstallDir
+                    Write-Green "Added to PATH. Restart your terminal for the change to take effect."
+                    Write-Host ""
+                }
+            } else {
+                Write-Host "Add it to your PATH:"
+                Write-Host "  `$env:Path = `"$InstallDir;`$env:Path`""
+                Write-Host ""
+                Write-Host "To persist across sessions:"
+                Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"$InstallDir;`" + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+            }
+        }
+
+        Write-Host "Get started:"
+        Write-Host "  musher --help"
+        Write-Host "  musher login"
+    } finally {
+        Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Main


### PR DESCRIPTION
## Summary
- Add PowerShell install script (`install.ps1`) for Windows users
- Include `install.ps1` in goreleaser release extra files
- Refresh README with updated descriptions, new commands (`add`, `pull`), Windows install instructions, and streamlined quick-start flow

## Test plan
- [ ] Verify `install.ps1` works on Windows PowerShell
- [ ] Confirm goreleaser picks up the new extra file
- [ ] Review README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)