### PR TITLE
ci: replace deprecated arduino/setup-task with go-task/setup-task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
           version: 3.x
 


### PR DESCRIPTION
## Summary
- Replace `arduino/setup-task@v2` (Node.js 20) with `go-task/setup-task@v2` (Node.js 24) in CI workflow
- Drop-in replacement — same inputs, same behavior
- Resolves the GitHub Actions Node.js 20 deprecation warning

## Test plan
- [ ] CI workflow passes without the Node.js 20 deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)