### PR TITLE
feat: align CLI with unified publish API and add yank --yes flag

### DIFF
--- a/cmd/musher/pull.go
+++ b/cmd/musher/pull.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -134,6 +136,16 @@ func runPull(cmd *cobra.Command, out *output.Writer, ref, outputDir string, forc
 		bundle, err = apiClient.PullPublicBundleVersion(ctx, namespace, slug, bundleVersion)
 	} else {
 		bundle, err = apiClient.PullBundleVersion(ctx, namespace, slug, bundleVersion)
+		// Fall back to the public hub endpoint when the namespace endpoint
+		// returns 403 (e.g. authenticated user pulling another user's public bundle).
+		if err != nil {
+			var httpErr *client.HTTPStatusError
+			if errors.As(err, &httpErr) && httpErr.Status == http.StatusForbidden {
+				cfg := configForPublicClient()
+				pubClient := newPublicAPIClient(cfg)
+				bundle, err = pubClient.PullPublicBundleVersion(ctx, namespace, slug, bundleVersion)
+			}
+		}
 	}
 
 	if err != nil {

--- a/cmd/musher/push.go
+++ b/cmd/musher/push.go
@@ -178,7 +178,6 @@ func runPush(cmd *cobra.Command, out *output.Writer, publishToHub, yes bool) err
 	}
 
 	req := &client.PushBundleRequest{
-		Slug:          bundle.Slug,
 		Name:          bundle.Name,
 		Description:   bundle.Description,
 		Visibility:    visibility,

--- a/cmd/musher/yank.go
+++ b/cmd/musher/yank.go
@@ -1,16 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	clierrors "github.com/musher-dev/musher-cli/internal/errors"
 	"github.com/musher-dev/musher-cli/internal/output"
+	"github.com/musher-dev/musher-cli/internal/prompt"
 )
 
 func newYankCmd() *cobra.Command {
+	var yes bool
+
 	cmd := &cobra.Command{
 		Use:   "yank <namespace/slug:version>",
 		Short: "Yank a published bundle version",
@@ -21,20 +23,22 @@ installed by default. However, they remain fetchable by digest
 for reproducibility — existing lockfiles that pin a digest will
 continue to resolve.`,
 		Example: `  musher yank acme/my-bundle:1.0.0
-  musher yank acme/my-bundle:1.0.0 --reason "security vulnerability"`,
+  musher yank acme/my-bundle:1.0.0 --reason "security vulnerability"
+  musher yank acme/my-bundle:1.0.0 --yes`,
 		Args: requireOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := output.FromContext(cmd.Context())
-			return runYank(cmd, out, args[0])
+			return runYank(cmd, out, args[0], yes)
 		},
 	}
 
 	cmd.Flags().String("reason", "", "reason for yanking this version")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 
 	return cmd
 }
 
-func runYank(cmd *cobra.Command, out *output.Writer, ref string) error {
+func runYank(cmd *cobra.Command, out *output.Writer, ref string, yes bool) error {
 	namespace, slug, version, err := parseVersionRef(ref)
 	if err != nil {
 		return err
@@ -47,15 +51,32 @@ func runYank(cmd *cobra.Command, out *output.Writer, ref string) error {
 		return authErr
 	}
 
-	spin := out.Spinner(fmt.Sprintf("Yanking %s/%s:%s", namespace, slug, version))
+	versionRef := namespace + "/" + slug + ":" + version
+
+	if !yes {
+		p := prompt.New(out)
+		if p.CanPrompt() {
+			confirmed, confirmErr := p.Confirm("Yank "+versionRef+"?", false)
+			if confirmErr != nil {
+				return clierrors.Wrap(clierrors.ExitGeneral, "Prompt failed", confirmErr)
+			}
+
+			if !confirmed {
+				out.Muted("Yank canceled.")
+				return nil
+			}
+		}
+	}
+
+	spin := out.Spinner("Yanking " + versionRef)
 	spin.Start()
 
 	if err := c.YankBundleVersion(cmd.Context(), namespace, slug, version, reason); err != nil {
-		spin.StopWithFailure(fmt.Sprintf("Failed to yank %s/%s:%s", namespace, slug, version))
+		spin.StopWithFailure("Failed to yank " + versionRef)
 		return clierrors.YankFailed(version, err)
 	}
 
-	spin.StopWithSuccess(fmt.Sprintf("Yanked %s/%s:%s", namespace, slug, version))
+	spin.StopWithSuccess("Yanked " + versionRef)
 
 	return nil
 }

--- a/internal/client/client_publish.go
+++ b/internal/client/client_publish.go
@@ -28,12 +28,11 @@ type PushBundleAsset struct {
 	MediaType   string `json:"mediaType,omitempty"`
 }
 
-// PushBundleRequest is the payload for the single-request push endpoint.
+// PushBundleRequest is the payload for the unified publish endpoint.
 type PushBundleRequest struct {
-	Slug          string            `json:"slug"`
-	Name          string            `json:"name"`
+	Name          string            `json:"name,omitempty"`
 	Description   string            `json:"description,omitempty"`
-	Visibility    string            `json:"visibility"`
+	Visibility    string            `json:"visibility,omitempty"`
 	Version       string            `json:"version"`
 	ReadmeContent string            `json:"readmeContent,omitempty"`
 	ReadmeFormat  string            `json:"readmeFormat,omitempty"`
@@ -42,7 +41,7 @@ type PushBundleRequest struct {
 
 // PushBundle pushes a bundle and all its assets in a single request.
 func (c *Client) PushBundle(ctx context.Context, namespace, bundleSlug string, req *PushBundleRequest) error {
-	path := fmt.Sprintf("/v1/namespaces/%s/bundles/%s:push",
+	path := fmt.Sprintf("/v1/namespaces/%s/bundles/%s:publish",
 		neturl.PathEscape(namespace),
 		neturl.PathEscape(bundleSlug),
 	)

--- a/internal/client/client_publish_test.go
+++ b/internal/client/client_publish_test.go
@@ -105,7 +105,6 @@ func TestPushBundle(t *testing.T) {
 		})
 
 		req := &client.PushBundleRequest{
-			Slug:          "my-bundle",
 			Name:          "My Bundle",
 			Description:   "A test bundle",
 			Visibility:    "private",
@@ -131,16 +130,12 @@ func TestPushBundle(t *testing.T) {
 			t.Errorf("method = %q, want POST", gotMethod)
 		}
 
-		if want := "/v1/namespaces/my-namespace/bundles/my-bundle:push"; gotPath != want {
+		if want := "/v1/namespaces/my-namespace/bundles/my-bundle:publish"; gotPath != want {
 			t.Errorf("path = %q, want %q", gotPath, want)
 		}
 
 		if gotAuth != "Bearer test-api-key" {
 			t.Errorf("auth = %q, want %q", gotAuth, "Bearer test-api-key")
-		}
-
-		if gotBody.Slug != "my-bundle" {
-			t.Errorf("body.Slug = %q, want %q", gotBody.Slug, "my-bundle")
 		}
 
 		if gotBody.Version != "1.0.0" {
@@ -170,7 +165,6 @@ func TestPushBundle(t *testing.T) {
 		})
 
 		req := &client.PushBundleRequest{
-			Slug:       "my-bundle",
 			Name:       "My Bundle",
 			Visibility: "private",
 			Version:    "1.0.0",


### PR DESCRIPTION
## Summary
- Update push endpoint from `:push` to `:publish` to match the unified publish API from musher-dev/platform#316
- Remove `slug` from the request body (now derived from URL path parameter)
- Add 403→public fallback when pulling cross-namespace public bundles while authenticated
- Add `--yes`/`-y` flag to `musher yank` for CI/scripting use

## Test plan
- [x] `musher push --yes` publishes via new `:publish` endpoint
- [x] `musher pull namespace/slug:version` downloads assets (authenticated)
- [x] `musher pull` falls back to public endpoint on 403 (cross-namespace)
- [x] `musher pull` public hub bundles work unauthenticated
- [x] `musher yank --yes` skips confirmation prompt
- [x] All unit tests pass
- [x] All lint checks pass
- [x] Cross-platform compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)