### PR TITLE
docs: update all references for bundle subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ go install github.com/musher-dev/musher-cli/cmd/musher@latest
 
 - **Musher CLI** — installed above.
 - **A Musher account and API key** — create or manage keys at [console.musher.dev](https://console.musher.dev/settings/organization/api-keys).
-- **Agent assets to publish** — start fresh with `musher init` to scaffold a new bundle project, or run `musher init --empty` then `musher add` to bundle existing agent assets in your project.
+- **Agent assets to publish** — start fresh with `musher bundle init` to scaffold a new bundle project, or run `musher bundle init --empty` then `musher bundle add` to bundle existing agent assets in your project.
 
 ## Quick Start
 
@@ -58,18 +58,18 @@ musher auth status
 **New bundle project:**
 
 ```bash
-musher init       # scaffolds musher.yaml, skill templates, README.md
-musher validate
-musher push
+musher bundle init       # scaffolds musher.yaml, skill templates, README.md
+musher bundle validate
+musher bundle push
 ```
 
 **Existing project:**
 
 ```bash
-musher init --empty   # creates musher.yaml only
-musher add --all      # discovers and registers conventional assets
-musher validate
-musher push
+musher bundle init --empty   # creates musher.yaml only
+musher bundle add --all      # discovers and registers conventional assets
+musher bundle validate
+musher bundle push
 ```
 
 Optionally, list on the public Hub:
@@ -80,8 +80,8 @@ musher hub publish <namespace/slug>
 
 ## Registry vs Hub
 
-- **Registry** — Where versioned bundles live. Private by default. Every `musher push` creates an immutable, content-addressable version.
-- **Hub** — The public discovery layer at [hub.musher.dev](https://hub.musher.dev). A separate action (`musher hub publish` or `musher push --publish-to-hub`) creates a listing. Requires `description`, `readme`, and `license` or `licenseFile` in `musher.yaml`.
+- **Registry** — Where versioned bundles live. Private by default. Every `musher bundle push` creates an immutable, content-addressable version.
+- **Hub** — The public discovery layer at [hub.musher.dev](https://hub.musher.dev). A separate action (`musher hub publish` or `musher bundle push --publish-to-hub`) creates a listing. Requires `description`, `readme`, and `license` or `licenseFile` in `musher.yaml`.
 
 You can push bundles without listing them on the Hub.
 
@@ -146,17 +146,18 @@ assets:
 | `musher auth logout` | Clear stored credentials |
 | `musher auth status` | Show current authentication status and writable namespaces |
 
-### Publishing
+### Authoring
 
 | Command | Description |
 |---------|-------------|
-| `musher init` | Scaffold a bundle project. Use `--empty` for definition only |
-| `musher add [path...]` | Register assets in `musher.yaml`. Use `--all` to discover conventional assets |
-| `musher validate` | Validate bundle definition and assets |
-| `musher push` | Push bundle to the registry. Use `--publish-to-hub` to also create a Hub listing |
-| `musher pull <ns/slug[:version]>` | Download a bundle. Use `-o` to extract to a directory |
-| `musher yank <ns/slug:version>` | Yank a published version. Use `--reason` to record why |
-| `musher unyank <ns/slug:version>` | Restore a yanked version |
+| `musher bundle init` | Scaffold a bundle project. Use `--empty` for definition only |
+| `musher bundle add [path...]` | Register assets in `musher.yaml`. Use `--all` to discover conventional assets |
+| `musher bundle remove [id-or-path...]` | Remove assets from `musher.yaml`. Use `--all` to remove all |
+| `musher bundle validate` | Validate bundle definition and assets |
+| `musher bundle push` | Push bundle to the registry. Use `--publish-to-hub` to also create a Hub listing |
+| `musher bundle pull <ns/slug[:version]>` | Download a bundle. Use `-o` to extract to a directory |
+| `musher bundle yank <ns/slug:version>` | Yank a published version. Use `--reason` to record why |
+| `musher bundle unyank <ns/slug:version>` | Restore a yanked version |
 
 ### Hub
 

--- a/internal/bundledef/bundledef.go
+++ b/internal/bundledef/bundledef.go
@@ -37,7 +37,7 @@ func Resolve(dir string) (string, error) {
 		return alt, nil
 	}
 
-	return "", fmt.Errorf("bundle definition file not found: %s or %s (run 'musher init' to create one)", primary, alt)
+	return "", fmt.Errorf("bundle definition file not found: %s or %s (run 'musher bundle init' to create one)", primary, alt)
 }
 
 // Asset kind constants.

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -197,7 +197,7 @@ func PublishFailed(cause error) *CLIError {
 func VersionConflict(versionRef string, cause error) *CLIError {
 	return enrichFromCause(&CLIError{
 		Message:   fmt.Sprintf("Version %s already exists", versionRef),
-		Hint:      "Bump the version in musher.yaml and try again, or use 'musher yank' to remove the existing version",
+		Hint:      "Bump the version in musher.yaml and try again, or use 'musher bundle yank' to remove the existing version",
 		Cause:     cause,
 		Code:      ExitGeneral,
 		ErrorCode: "ERR-PUBLISH-CONFLICT",
@@ -208,7 +208,7 @@ func VersionConflict(versionRef string, cause error) *CLIError {
 func ValidateFailed(msg string) *CLIError {
 	return &CLIError{
 		Message: "Validation failed: " + msg,
-		Hint:    "Fix the issues above and run 'musher validate' again",
+		Hint:    "Fix the issues above and run 'musher bundle validate' again",
 		Code:    ExitGeneral,
 	}
 }


### PR DESCRIPTION
## Summary

- Update 17 stale command references in `README.md` from flat `musher <verb>` to `musher bundle <verb>`
- Update 2 error hint messages in `internal/errors/errors.go` (`musher yank` → `musher bundle yank`, `musher validate` → `musher bundle validate`)
- Update 1 resolver hint in `internal/bundledef/bundledef.go` (`musher init` → `musher bundle init`)
- Rename README commands section from "Publishing" to "Authoring" and add missing `bundle remove` command to the table

Follow-up to #42 which grouped bundle commands under the `musher bundle` subcommand.

## Test plan

- [x] `task check` passes (fmt, lint, vuln scan, tests, cross-compilation)
- [x] `grep` confirms no stale `musher <verb>` references remain outside of CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)